### PR TITLE
feat: Layer 3 — KMS CMK with S3/EBS encryption defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![AWS](https://img.shields.io/badge/AWS-Organizations%20%7C%20IAM%20%7C%20S3-FF9900?style=flat&logo=amazonwebservices)
+![AWS](https://img.shields.io/badge/AWS-Organizations%20%7C%20CloudTrail%20%7C%20IAM%20%7C%20KMS-FF9900?style=flat&logo=amazonwebservices)
 ![CloudFormation](https://img.shields.io/badge/IaC-CloudFormation-blue?style=flat&logo=amazonwebservices)
 ![License](https://img.shields.io/badge/License-MIT-green?style=flat)
 ![Compliance](https://img.shields.io/badge/Compliance-as%20Code-blueviolet?style=flat)
@@ -17,16 +17,21 @@ The controls in this repository map to requirements from CJIS Security Policy, F
 ```mermaid
 graph TD
     A[AWS Organization] --> B[Organization Root]
-    B --> C["SCP: Deny Audit Log Deletion"]
-    B --> D["SCP: Deny EC2 Actions"]
-    B --> E["SCP: Prevent Insecure SSH"]
-    B --> F["SCP: Require S3 Encryption"]
-    B --> G[Organizational Units / Accounts]
-    G --> H[CloudFormation Stack]
-    H --> I["Secure S3 Bucket<br/>Public Access Blocked<br/>AES256 Encryption"]
+    B --> SCP["Service Control Policies<br/>Preventive Guardrails"]
+    SCP --> S1["Deny Audit Log Deletion"]
+    SCP --> S2["Deny Root User Usage"]
+    SCP --> S3["Protect Logging and Encryption"]
+    SCP --> S4["Require S3 KMS Encryption"]
+    SCP --> S5["Restrict Network Changes by Region"]
+    B --> ACC["Member Account"]
+    ACC --> L1["Layer 1 (01-logging.yaml)<br/>CloudTrail + Object Lock S3 + VPC Flow Logs"]
+    ACC --> L2["Layer 2 (02-iam-baseline.yaml)<br/>Password Policy + Auditor and Admin Roles"]
+    ACC --> L3["Layer 3 (03-encryption.yaml)<br/>KMS CMK + EBS Default Encryption"]
+    ACC --> SB["secure-bucket.yaml<br/>Secure S3 Bucket"]
+    L3 -. exports CMK ARN .-> L1
 ```
 
-SCPs are attached at the Organization Root, enforcing preventive guardrails across all accounts. These policies override IAM permissions, including administrator access, so non-compliant actions are blocked before they happen. CloudFormation templates are deployed into individual accounts to provision resources that meet security baselines without manual configuration. Together, they create a defense-in-depth model where organization-level policies and account-level infrastructure work in tandem.
+SCPs are attached at the Organization Root, enforcing preventive guardrails across all accounts. These policies override IAM permissions, including administrator access, so non-compliant actions are blocked before they happen. CloudFormation templates are deployed into member accounts as numbered layers (`01` → `02` → `03`), each building on the previous, to provision resources that meet security baselines without manual configuration. Together, they create a defense-in-depth model where organization-level policies and account-level infrastructure work in tandem.
 
 ## Compliance Frameworks
 
@@ -44,25 +49,33 @@ The [Federal Risk and Authorization Management Program (FedRAMP)](https://www.fe
 
 ## Controls Implemented
 
-| Control | File | Type | What It Enforces | Security Principle |
+| Control / Component | File | Type | What It Enforces | Security Principle |
 |---|---|---|---|---|
-| Deny Audit Log Deletion | `scps/scp-deny-audit-log-deletion.json` | SCP (Preventive) | Blocks `cloudtrail:DeleteTrail` and `cloudtrail:StopLogging` across the organization | Audit Integrity |
-| Deny EC2 Actions | `scps/scp-deny-ec2-actions.json` | SCP (Preventive) | Denies all EC2 actions (`ec2:*`) org-wide, restricting unauthorized compute usage | Least Functionality |
-| Prevent Insecure SSH | `scps/scp-prevent-insecure-ssh.json` | SCP (Preventive) | Blocks security group rules that open SSH (port 22) to `0.0.0.0/0` in `us-west-1` | Network Boundary Protection |
-| Require S3 Encryption | `scps/scp-require-s3-encryption.json` | SCP (Preventive) | Denies S3 bucket creation when encryption is not enabled | Data Protection at Rest |
-| Secure S3 Bucket | `cloudformation/secure-bucket.yaml` | CloudFormation (IaC) | Deploys an S3 bucket with all public access blocked and AES256 server-side encryption | Secure by Default |
+| Deny Audit Log Deletion | `scps/scp-deny-audit-log-deletion.json` | SCP (Preventive) | Denies `cloudtrail:DeleteTrail` and `cloudtrail:StopLogging` org-wide | Audit Integrity |
+| Deny Root User Usage | `scps/scp-deny-root-usage.json` | SCP (Preventive) | Denies all actions by the account root user, except MFA enrollment, account summary, and AWS Support | Least Privilege |
+| Protect Logging and Encryption | `scps/scp-protect-logging-and-encryption.json` | SCP (Preventive) | Denies `ec2:DeleteFlowLogs` and `ec2:DisableEbsEncryptionByDefault`, guarding the Layer 1 and Layer 3 controls | Audit Integrity / Data Protection |
+| Require S3 KMS Encryption | `scps/scp-require-s3-encryption.json` | SCP (Preventive) | Denies `s3:PutObject` unless the request specifies `aws:kms` server-side encryption | Data Protection at Rest |
+| Restrict Network Changes by Region | `scps/scp-restrict-network-changes-by-region.json` | SCP (Preventive) | Denies security group ingress/egress changes outside approved regions (`us-east-1`, `us-west-2`) | Network Boundary Protection |
+| Layer 1 — Logging and Monitoring | `cloudformation/01-logging.yaml` | CloudFormation (IaC) | Multi-region CloudTrail, an Object Lock (COMPLIANCE mode) log bucket, a CloudWatch log group, and VPC Flow Logs | Audit and Accountability |
+| Layer 2 — IAM Baseline | `cloudformation/02-iam-baseline.yaml` | CloudFormation (IaC) | Account password policy, a read-only auditor role, and an MFA + ExternalId admin role capped by a permissions boundary | Identity and Least Privilege |
+| Layer 3 — Encryption | `cloudformation/03-encryption.yaml` | CloudFormation (IaC) | Customer-managed KMS CMK with annual rotation, a separated key policy, and account-level EBS encryption-by-default | Data Protection at Rest |
+| Secure S3 Bucket | `cloudformation/secure-bucket.yaml` | CloudFormation (IaC) | An S3 bucket with all public access blocked and AES256 server-side encryption | Secure by Default |
 
 ## Compliance Framework Mapping
 
 Each control was selected to address specific compliance requirements across CJIS Security Policy, FedRAMP, and NIST 800-53. The combination of preventive SCPs and compliant-by-default IaC templates creates layered enforcement; SCPs act as guardrails that cannot be bypassed even by IAM administrators, while CloudFormation ensures new resources are provisioned to meet baseline security requirements without manual configuration.
 
-| Control | CJIS Security Policy (v6.0) | FedRAMP Baseline | NIST 800-53 Rev. 5 |
+| Control / Component | CJIS Security Policy (v6.0) | FedRAMP Baseline | NIST 800-53 Rev. 5 |
 |---|---|---|---|
 | Deny Audit Log Deletion | AU-9 (Protection of Audit Information), AU-12 (Audit Record Generation) | AU-9 (L/M/H), AU-12 (L/M/H) | AU-9 (Protection of Audit Information), AU-12 (Audit Record Generation) |
-| Deny EC2 Actions | CM-7 (Least Functionality), AC-6 (Least Privilege) | CM-7 (L/M/H), AC-6 (M/H) | CM-7 (Least Functionality), AC-6 (Least Privilege) |
-| Prevent Insecure SSH | SC-7 (Boundary Protection), AC-17 (Remote Access) | SC-7 (L/M/H), AC-17 (L/M/H) | SC-7 (Boundary Protection), AC-17 (Remote Access) |
-| Require S3 Encryption | SC-28 (Protection of Information at Rest), SC-13 (Cryptographic Protection) | SC-28 (M/H), SC-13 (L/M/H) | SC-28 (Protection of Information at Rest), SC-13 (Cryptographic Protection) |
-| Secure S3 Bucket (CFn) | SC-28 (Protection of Information at Rest), AC-3 (Access Enforcement) | SC-28 (M/H), AC-3 (L/M/H) | SC-28 (Protection of Information at Rest), AC-3 (Access Enforcement) |
+| Deny Root User Usage | AC-6 (Least Privilege), AC-3 (Access Enforcement) | AC-6 (M/H), AC-3 (L/M/H) | AC-6 (Least Privilege), AC-3 (Access Enforcement) |
+| Protect Logging and Encryption | AU-9 (Protection of Audit Information), SC-28 (Protection of Information at Rest) | AU-9 (L/M/H), SC-28 (M/H) | AU-9 (Protection of Audit Information), SC-28 (Protection of Information at Rest) |
+| Require S3 KMS Encryption | SC-28 (Protection of Information at Rest), SC-13 (Cryptographic Protection) | SC-28 (M/H), SC-13 (L/M/H) | SC-28 (Protection of Information at Rest), SC-13 (Cryptographic Protection) |
+| Restrict Network Changes by Region | SC-7 (Boundary Protection) | SC-7 (L/M/H) | SC-7 (Boundary Protection) |
+| Layer 1 — Logging and Monitoring | AU-2 (Event Logging), AU-3 (Content of Audit Records), AU-9, AU-12 | AU-2 (L/M/H), AU-3 (L/M/H), AU-9 (L/M/H), AU-12 (L/M/H) | AU-2 (Event Logging), AU-3 (Content of Audit Records), AU-9 (Protection of Audit Information), AU-12 (Audit Record Generation) |
+| Layer 2 — IAM Baseline | AC-2 (Account Management), AC-3 (Access Enforcement), AC-6 (Least Privilege), IA-5 (Authenticator Management) | AC-2 (L/M/H), AC-3 (L/M/H), AC-6 (M/H), IA-5 (L/M/H) | AC-2 (Account Management), AC-3 (Access Enforcement), AC-6 (Least Privilege), IA-5 (Authenticator Management) |
+| Layer 3 — Encryption | SC-12 (Cryptographic Key Management), SC-13 (Cryptographic Protection), SC-28, SC-28(1) | SC-12 (L/M/H), SC-13 (L/M/H), SC-28 (M/H), SC-28(1) (M/H) | SC-12 (Cryptographic Key Establishment and Management), SC-13 (Cryptographic Protection), SC-28 (Protection of Information at Rest), SC-28(1) (Cryptographic Protection) |
+| Secure S3 Bucket | SC-28 (Protection of Information at Rest), AC-3 (Access Enforcement) | SC-28 (M/H), AC-3 (L/M/H) | SC-28 (Protection of Information at Rest), AC-3 (Access Enforcement) |
 
 > **Note:** CJIS v6.0 now uses NIST 800-53 control identifiers directly, so the CJIS and NIST columns share the same control IDs. The distinction is that CJIS scopes these requirements specifically to Criminal Justice Information (CJI), while NIST 800-53 applies broadly to federal information systems.
 
@@ -73,23 +86,33 @@ Each control was selected to address specific compliance requirements across CJI
 ```
 aws-compliance-as-code/
 ├── cloudformation/
-│   └── secure-bucket.yaml              # CloudFormation: Secure S3 bucket (public access block + AES256)
+│   ├── 01-logging.yaml                 # Layer 1: CloudTrail + Object Lock S3 + CloudWatch + VPC Flow Logs
+│   ├── 02-iam-baseline.yaml            # Layer 2: IAM password policy + auditor/admin roles
+│   ├── 03-encryption.yaml              # Layer 3: KMS CMK + alias + EBS encryption-by-default
+│   └── secure-bucket.yaml              # Standalone: secure S3 bucket (public access block + AES256)
 ├── scps/
-│   ├── scp-deny-audit-log-deletion.json    # SCP: Prevent CloudTrail deletion/stop logging
-│   ├── scp-deny-ec2-actions.json           # SCP: Deny all EC2 actions org-wide
-│   ├── scp-prevent-insecure-ssh.json       # SCP: Block SSH port 22 open to 0.0.0.0/0 (us-west-1)
-│   └── scp-require-s3-encryption.json      # SCP: Require encryption on S3 bucket creation
+│   ├── scp-deny-audit-log-deletion.json            # SCP: Deny CloudTrail DeleteTrail / StopLogging
+│   ├── scp-deny-root-usage.json                    # SCP: Deny root user actions (except MFA setup / support)
+│   ├── scp-protect-logging-and-encryption.json     # SCP: Deny DeleteFlowLogs / DisableEbsEncryptionByDefault
+│   ├── scp-require-s3-encryption.json              # SCP: Deny S3 PutObject without SSE-KMS
+│   └── scp-restrict-network-changes-by-region.json # SCP: Deny security group changes outside approved regions
 ├── LICENSE.txt                         # MIT License
 └── README.md
 ```
 
+The numbered CloudFormation prefixes (`01`–`03`) indicate deployment order; each layer builds on the one before it.
+
 ## AWS Services Used
 
-- **[AWS Organizations](https://aws.amazon.com/organizations/)**: Hosts the SCPs and enforces guardrails across the account hierarchy
-- **[AWS CloudFormation](https://aws.amazon.com/cloudformation/)**: Deploys compliant infrastructure as code (secure S3 bucket template)
-- **[AWS IAM](https://aws.amazon.com/iam/)**: Underlying permission system that SCPs override at the organization level
-- **[AWS S3](https://aws.amazon.com/s3/)**: Target service for the secure bucket deployment and encryption enforcement
-- **[AWS CloudTrail](https://aws.amazon.com/cloudtrail/)**: Audit logging service protected by the audit log deletion SCP
+- **[AWS Organizations](https://aws.amazon.com/organizations/)**: Hosts the SCPs and enforces preventive guardrails across the account hierarchy
+- **[AWS CloudFormation](https://aws.amazon.com/cloudformation/)**: Deploys the layered compliance infrastructure as code
+- **[AWS CloudTrail](https://aws.amazon.com/cloudtrail/)**: Multi-region API audit logging (Layer 1)
+- **[AWS KMS](https://aws.amazon.com/kms/)**: Customer-managed key for encryption at rest (Layer 3)
+- **[AWS IAM](https://aws.amazon.com/iam/)**: Password policy, scoped roles, and permissions boundary (Layer 2)
+- **[Amazon S3](https://aws.amazon.com/s3/)**: Object Lock log storage and the secure bucket baseline
+- **[Amazon EBS](https://aws.amazon.com/ebs/)**: Account-level encryption-by-default for new volumes (Layer 3)
+- **[Amazon CloudWatch Logs](https://aws.amazon.com/cloudwatch/)**: Hot, queryable copy of CloudTrail and VPC Flow Log events
+- **[AWS Lambda](https://aws.amazon.com/lambda/)**: Backs the custom resources for account settings with no native CloudFormation type
 - **[AWS CLI](https://aws.amazon.com/cli/)**: Interface for deploying SCPs and CloudFormation stacks
 
 ## How It Works
@@ -100,7 +123,7 @@ SCPs are attached at the Organization Root and act as permission boundaries that
 
 ### CloudFormation (Compliant by Default)
 
-CloudFormation templates encode security requirements directly into resource definitions. The secure S3 bucket template in this project provisions a bucket with public access blocked and encryption enabled every time it deploys, eliminating the possibility of configuration drift or manual misconfiguration. The template itself serves as auditable documentation of the intended secure state.
+CloudFormation templates encode security requirements directly into resource definitions, so resources deploy in their intended secure state every time, eliminating configuration drift and manual misconfiguration. The templates are organized as numbered layers (`01-logging.yaml` → `02-iam-baseline.yaml` → `03-encryption.yaml`) that build on one another — Layer 3's KMS key, for example, is exported and adopted by Layer 1's CloudTrail log bucket. Each template is auditable documentation of the intended secure state.
 
 ### Defense in Depth
 
@@ -233,24 +256,53 @@ Example output:
 ------------------------------------------------------
 ```
 
-### Step 3: Deploy CloudFormation Stack
+### Step 3: Deploy the CloudFormation Layers
+
+Deploy the numbered templates in order — each layer builds on the previous. All three layers create IAM resources, so `CAPABILITY_NAMED_IAM` is required. (`secure-bucket.yaml` is a standalone foundational template and can be deployed independently.)
+
+**Layer 1 — Logging & Monitoring.** Leave `LogsBucketCmkArn` unset for now; the CloudTrail log bucket uses SSE-S3 until the Layer 3 CMK exists.
 
 ```
 aws cloudformation deploy \
-    --stack-name <STACK_NAME> \
-    --template-file <STACK_FILENAME.yaml> \
-    --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
-    --parameter-overrides \
-        OrganizationId=<YOUR_ORG_ID> \
-        OrgRootId=<ORG_ROOT_ID>
+    --stack-name compliance-layer1-logging \
+    --template-file cloudformation/01-logging.yaml \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --parameter-overrides DefaultVpcId=<DEFAULT_VPC_ID>
 ```
 
-Example output:
+**Layer 2 — IAM Baseline.** Supply a long random `AdminRoleExternalId`.
 
 ```
-Waiting for changeset to be created..
-Waiting for stack create/update to complete
-Successfully created/updated stack - <BUCKET_NAME>
+aws cloudformation deploy \
+    --stack-name compliance-layer2-iam \
+    --template-file cloudformation/02-iam-baseline.yaml \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --parameter-overrides AdminRoleExternalId=<LONG_RANDOM_STRING>
+```
+
+**Layer 3 — Encryption.** Pass the Layer 2 admin role ARN as the key administrator.
+
+```
+aws cloudformation deploy \
+    --stack-name compliance-layer3-encryption \
+    --template-file cloudformation/03-encryption.yaml \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --parameter-overrides KeyAdministratorRoleArn=$(aws cloudformation describe-stacks \
+        --stack-name compliance-layer2-iam \
+        --query "Stacks[0].Outputs[?OutputKey=='AdminRoleArn'].OutputValue" --output text)
+```
+
+**Second pass — wire the CMK into Layer 1.** Re-deploy Layer 1 with the Layer 3 CMK ARN to switch the CloudTrail log bucket to SSE-KMS (agency-managed key). This two-pass step breaks the cycle: Layer 1 is numbered first but its encryption key is created in Layer 3.
+
+```
+aws cloudformation deploy \
+    --stack-name compliance-layer1-logging \
+    --template-file cloudformation/01-logging.yaml \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --parameter-overrides DefaultVpcId=<DEFAULT_VPC_ID> \
+        LogsBucketCmkArn=$(aws cloudformation describe-stacks \
+        --stack-name compliance-layer3-encryption \
+        --query "Stacks[0].Outputs[?OutputKey=='ComplianceCmkArn'].OutputValue" --output text)
 ```
 
 **Verify deployment:**

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Example output:
 |------------------------------|--------------|
 |  SCP-DenyRootUserActions     |  p-1a2b3c4d  |
 |  SCP-DenyAuditLogDeletion    |  p-5e6f7g8h  |
-|  SCP-PreventOpenSSH          |  p-9j0k1l2m  |
+|  SCP-RestrictNetworkChanges  |  p-9j0k1l2m  |
 ----------------------------------------------
 ```
 
@@ -280,16 +280,18 @@ aws cloudformation deploy \
     --parameter-overrides AdminRoleExternalId=<LONG_RANDOM_STRING>
 ```
 
-**Layer 3 — Encryption.** Pass the Layer 2 admin role ARN as the key administrator.
+**Layer 3 — Encryption.** Pass the Layer 2 admin role as key administrator and the Layer 2 auditor role as key user (so it can decrypt CloudTrail logs for evidence collection).
 
 ```
 aws cloudformation deploy \
     --stack-name compliance-layer3-encryption \
     --template-file cloudformation/03-encryption.yaml \
     --capabilities CAPABILITY_NAMED_IAM \
-    --parameter-overrides KeyAdministratorRoleArn=$(aws cloudformation describe-stacks \
-        --stack-name compliance-layer2-iam \
-        --query "Stacks[0].Outputs[?OutputKey=='AdminRoleArn'].OutputValue" --output text)
+    --parameter-overrides \
+        KeyAdministratorRoleArn=$(aws cloudformation describe-stacks --stack-name compliance-layer2-iam \
+            --query "Stacks[0].Outputs[?OutputKey=='AdminRoleArn'].OutputValue" --output text) \
+        KeyUserRoleArns=$(aws cloudformation describe-stacks --stack-name compliance-layer2-iam \
+            --query "Stacks[0].Outputs[?OutputKey=='AuditorRoleArn'].OutputValue" --output text)
 ```
 
 **Second pass — wire the CMK into Layer 1.** Re-deploy Layer 1 with the Layer 3 CMK ARN to switch the CloudTrail log bucket to SSE-KMS (agency-managed key). This two-pass step breaks the cycle: Layer 1 is numbered first but its encryption key is created in Layer 3.
@@ -329,7 +331,7 @@ aws organizations update-policy \
 aws cloudformation deploy \
     --stack-name <STACK_NAME> \
     --template-file <STACK_FILENAME>.yaml \
-    --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND
+    --capabilities CAPABILITY_NAMED_IAM
 ```
 
 ### Resource Cleanup
@@ -367,7 +369,7 @@ aws cloudformation delete-stack \
 
 This project demonstrates the core GRC Engineering skill of translating compliance framework requirements into enforceable AWS controls. It showcases hands-on experience with AWS Organizations policy design, SCP authoring with condition-based logic, CloudFormation template development, and compliance framework mapping across CJIS Security Policy, FedRAMP, and NIST 800-53. The inclusion of CJIS and FedRAMP mappings reflects relevance to criminal justice environments and federal cloud authorization requirements.
 
-The controls were selected to illustrate a range of enforcement patterns, from broad service restrictions (`ec2:*` deny) to condition-based rules (SSH port + CIDR + region matching) to encryption mandates, demonstrating the flexibility of SCPs as a compliance enforcement mechanism.
+The controls illustrate a range of enforcement patterns — action-scoped denials (CloudTrail log deletion), principal-scoped denials (root-user lockdown via `NotAction` plus an `aws:PrincipalArn` condition), region-conditioned rules (network changes confined to approved regions), and encryption mandates (S3 uploads required to use SSE-KMS) — alongside a layered, compliant-by-default CloudFormation baseline. Together they demonstrate the flexibility of SCPs and infrastructure-as-code as compliance enforcement mechanisms.
 
 This foundation positions the project for expansion into CI/CD pipeline guardrails, AWS Config rules for continuous compliance monitoring, drift remediation automation, and multi-account architectures with OU-scoped policies.
 

--- a/cloudformation/01-logging.yaml
+++ b/cloudformation/01-logging.yaml
@@ -4,8 +4,8 @@ Description: >-
   tamper-proof S3 log bucket (Object Lock in COMPLIANCE mode), a CloudWatch
   Log Group for near-real-time delivery, and a VPC Flow Log on the default VPC.
   Satisfies NIST 800-53 Rev 5 AU-2, AU-3, AU-9, AU-12. Partial CJIS v6.0
-  5.4.1 - integrity controls in place; encryption-at-rest closure deferred
-  to Layer 3 (agency-managed CMK).
+  5.4.1 - integrity controls in place; encryption-at-rest closes by passing
+  the Layer 3 CMK ARN to the LogsBucketCmkArn parameter (agency-managed key).
 
 Parameters:
   TrailName:
@@ -37,6 +37,23 @@ Parameters:
       VPC to attach Flow Logs to. Select the default VPC for AC compliance;
       CloudFormation has no intrinsic for "default VPC", so it is parameterized.
 
+  LogsBucketCmkArn:
+    Type: String
+    Default: ""
+    Description: >-
+      ARN of the Layer 3 compliance CMK (03-encryption.yaml output
+      ComplianceCmkArn). Leave empty on the first deploy - Layer 3 does not
+      exist yet, so the logs bucket falls back to SSE-S3 (AES256). After
+      Layer 3 is deployed, update this stack with the CMK ARN to switch the
+      bucket to SSE-KMS with the agency-managed key (SC-28 / CJIS 5.10.1.2).
+      Two-pass by design: Layer 1 is numbered first but its encryption key is
+      created in Layer 3.
+
+Conditions:
+  # True once a Layer 3 CMK ARN has been supplied. Selects SSE-KMS (the
+  # agency-managed CMK) over the SSE-S3 fallback for the logs bucket.
+  UseCmkForLogsBucket: !Not [!Equals [!Ref LogsBucketCmkArn, ""]]
+
 Resources:
 
   # S3 bucket holding immutable CloudTrail log files. Object Lock must be
@@ -65,10 +82,22 @@ Resources:
         RestrictPublicBuckets: true
       BucketEncryption:
         ServerSideEncryptionConfiguration:
-          # SSE-S3 baseline. Layer 3 (KMS) replaces with a customer-managed CMK
-          # so CJIS v6.0 agency-managed-key requirements are met.
+          # SSE-KMS with the Layer 3 agency-managed CMK once its ARN is wired
+          # in via LogsBucketCmkArn; SSE-S3 (AES256) as the pre-Layer-3
+          # fallback. CJIS v6.0 5.10.1.2 requires an agency-managed key for
+          # CJI at rest - the CMK branch closes that gap; AES256 alone uses an
+          # AWS-managed key.
           - ServerSideEncryptionByDefault:
-              SSEAlgorithm: AES256
+              SSEAlgorithm: !If [UseCmkForLogsBucket, "aws:kms", "AES256"]
+              KMSMasterKeyID: !If
+                - UseCmkForLogsBucket
+                - !Ref LogsBucketCmkArn
+                - !Ref "AWS::NoValue"
+            # S3 Bucket Keys: with SSE-KMS, S3 generates one bucket-level key
+            # and derives per-object keys from it instead of calling KMS
+            # GenerateDataKey on every PUT - a large KMS cost cut for a
+            # high-volume log bucket. No effect under SSE-S3.
+            BucketKeyEnabled: !If [UseCmkForLogsBucket, true, !Ref "AWS::NoValue"]
       VersioningConfiguration:
         # Required for Object Lock; also lets a poisoned overwrite be ignored
         # because previous versions remain immutable.

--- a/cloudformation/03-encryption.yaml
+++ b/cloudformation/03-encryption.yaml
@@ -1,0 +1,258 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  Layer 3 - Encryption. Deploys a customer-managed KMS key (CMK) with annual
+  rotation and a key policy separating IAM delegation, key administration, and
+  key usage; a stable alias; and account-level EBS encryption-by-default (via a
+  Lambda-backed custom resource) pointed at the CMK. The CMK ARN is exported so
+  Layer 1 can adopt it for the CloudTrail logs bucket. Satisfies NIST 800-53
+  Rev 5 SC-12, SC-13, SC-28, SC-28(1). CJIS v6.0 5.10.1.2 - agency-managed key
+  for CJI at rest; an AWS-managed key would place AWS personnel in CJIS scope.
+
+Parameters:
+  KeyAdministratorRoleArn:
+    Type: String
+    AllowedPattern: "arn:aws:iam::[0-9]{12}:role/.+"
+    ConstraintDescription: Must be a full IAM role ARN (arn:aws:iam::<account>:role/<name>).
+    Description: >-
+      ARN of the IAM role designated to ADMINISTER the CMK. Use the Layer 2
+      admin role: <iam-baseline-stack-name>-admin. This role manages the key
+      but the Layer 2 AdminPermissionsBoundary still denies ScheduleKeyDeletion
+      / DisableKey / DeleteAlias, so it cannot destroy the key. No default -
+      the key administrator must be set explicitly on every deploy.
+
+  KeyAliasName:
+    Type: String
+    Default: alias/compliance-baseline-cmk
+    AllowedPattern: "alias/[a-zA-Z0-9/_-]+"
+    ConstraintDescription: Must start with "alias/" then alphanumerics, dashes, underscores, or slashes.
+    Description: >-
+      Friendly alias for the CMK. Callers reference the key by this stable
+      name; the key material can rotate without touching any reference.
+
+  PendingDeletionWindowInDays:
+    Type: Number
+    Default: 30
+    MinValue: 7
+    MaxValue: 30
+    Description: >-
+      Waiting period before a key scheduled for deletion is destroyed.
+      Destroying a CMK is irreversible and renders every byte encrypted under
+      it permanently unrecoverable, so 30 (the maximum) is the conservative
+      compliance choice - the longest window to catch a mistake.
+
+Resources:
+
+  # The customer-managed CMK. This is the "agency-managed key" CJIS v6.0
+  # (5.10.1.2) requires for CJI at rest: the account - not AWS - owns the key
+  # policy and the key lifecycle, so AWS personnel cannot decrypt data
+  # protected by it. An AWS-managed key (aws/s3, aws/ebs) cannot satisfy this
+  # because AWS controls that key's policy.
+  #
+  # DeletionPolicy / UpdateReplacePolicy Retain: deleting OR replacing a CMK
+  # destroys all data encrypted under it. CloudTrail evidence (AU-9) and EBS
+  # data must outlive a stack teardown, so the key is retained, never
+  # auto-scheduled for deletion when the stack is removed.
+  ComplianceCmk:
+    Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Description: >-
+        Compliance baseline CMK. Encrypts CloudTrail logs (S3) and EBS volumes
+        at rest. NIST 800-53 SC-12 / SC-13 / SC-28; CJIS v6.0 5.10.1.2.
+      KeySpec: SYMMETRIC_DEFAULT
+      KeyUsage: ENCRYPT_DECRYPT
+      # Single-region key. CLAUDE.md: do not span regions unless the control
+      # requires it - encryption at rest is satisfied per-region.
+      MultiRegion: false
+      PendingWindowInDays: !Ref PendingDeletionWindowInDays
+      # Annual rotation (SC-12). KMS generates fresh backing key material every
+      # 365 days; the key ID, ARN, and alias never change. Old material is kept
+      # so data encrypted before a rotation still decrypts - rotation does NOT
+      # re-encrypt existing data.
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: compliance-baseline-cmk-policy
+        Statement:
+
+          # Statement 1 - the IAM-delegation switch. A key policy is the ROOT
+          # OF TRUST for a KMS key: unlike most AWS services, an IAM policy
+          # granting kms:Decrypt does nothing unless the key policy also allows
+          # it. Naming the account root principal (":root" = the ACCOUNT, not
+          # the root USER) is what makes IAM policies in this account effective
+          # for this key. AWS documents that removing this statement can
+          # permanently ORPHAN the key - if the named admin principals are
+          # later deleted, no one, not even AWS, can regain control. Kept by
+          # design.
+          - Sid: EnableIamPolicyDelegation
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
+
+          # Statement 2 - the designated KEY ADMINISTRATOR. Names the admin
+          # role IN the key policy so the resource policy itself documents who
+          # governs the key (SC-12), auditable without cross-referencing IAM.
+          # The action list is management-only - it omits Encrypt / Decrypt /
+          # GenerateDataKey. (Because Statement 1 delegates to IAM, whether
+          # this role can also USE the key depends on its IAM policy; see the
+          # PR notes on that trade-off.)
+          - Sid: AllowKeyAdministration
+            Effect: Allow
+            Principal:
+              AWS: !Ref KeyAdministratorRoleArn
+            Action:
+              - kms:Create*
+              - kms:Describe*
+              - kms:Enable*
+              - kms:List*
+              - kms:Put*
+              - kms:Update*
+              - kms:Revoke*
+              - kms:Disable*
+              - kms:Get*
+              - kms:Delete*
+              - kms:TagResource
+              - kms:UntagResource
+              - kms:ScheduleKeyDeletion
+              - kms:CancelKeyDeletion
+              - kms:RotateKeyOnDemand
+            Resource: "*"
+
+          # Statement 3 - CloudTrail as a KEY USER. Once Layer 1's logs bucket
+          # uses SSE-KMS, CloudTrail must call GenerateDataKey to encrypt each
+          # log file it delivers (envelope encryption: KMS returns a data key,
+          # CloudTrail encrypts the log with it, the encrypted data key is
+          # stored beside the object). aws:SourceAccount blocks a trail in any
+          # other account from using this key - the same confused-deputy guard
+          # Layer 1's bucket policy already applies to CloudTrail.
+          - Sid: AllowCloudTrailToEncryptLogs
+            Effect: Allow
+            Principal:
+              Service: cloudtrail.amazonaws.com
+            Action:
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+
+  # Alias = a stable, human-readable handle for the key. Templates and callers
+  # reference alias/... so the underlying key can be replaced without
+  # rewriting every reference.
+  ComplianceCmkAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Ref KeyAliasName
+      TargetKeyId: !Ref ComplianceCmk
+
+  # EBS encryption-by-default is an account + region toggle with no native
+  # CloudFormation resource type (the same gap Layer 2 hit with the IAM
+  # password policy). The pattern: a Lambda-backed custom resource that
+  # translates CFN Create / Update / Delete events into EC2 API calls.
+  #
+  # Execution role - least privilege: basic Lambda logging plus exactly the
+  # five EBS-encryption verbs.
+  EbsEncryptionLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: ManageEbsEncryptionDefault
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              # These EC2 actions act on the account/region, not on a resource
+              # with an ARN, so Resource MUST be "*" - the same justified AC-6
+              # exception Layer 2 documents for the password-policy Lambda.
+              - Effect: Allow
+                Action:
+                  - ec2:EnableEbsEncryptionByDefault
+                  - ec2:GetEbsEncryptionByDefault
+                  - ec2:ModifyEbsDefaultKmsKeyId
+                  - ec2:GetEbsDefaultKmsKeyId
+                  - ec2:ResetEbsDefaultKmsKeyId
+                Resource: "*"
+
+  EbsEncryptionLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-ebs-encryption-cr"
+      Runtime: python3.12
+      Handler: index.handler
+      Role: !GetAtt EbsEncryptionLambdaRole.Arn
+      Timeout: 60
+      Code:
+        ZipFile: |
+          import boto3
+          import cfnresponse
+
+          # A FIXED physical resource ID. Account-scoped settings have no
+          # natural ARN. Keeping the ID constant across Create and Update means
+          # CloudFormation never sees the custom resource as "replaced", so an
+          # Update (e.g. a new CmkArn) does not trigger a spurious Delete that
+          # would reset the EBS default key right after setting it.
+          PHYSICAL_ID = 'ebs-encryption-by-default'
+
+          def handler(event, context):
+              ec2 = boto3.client('ec2')
+              props = event.get('ResourceProperties', {})
+              request_type = event['RequestType']
+
+              try:
+                  if request_type in ('Create', 'Update'):
+                      # Encryption-by-default: every new EBS volume in this
+                      # region is encrypted with no per-volume opt-in (SC-28).
+                      ec2.enable_ebs_encryption_by_default()
+                      # Point the default at the agency-managed CMK instead of
+                      # the AWS-managed aws/ebs key (SC-12).
+                      ec2.modify_ebs_default_kms_key_id(KmsKeyId=props['CmkArn'])
+                  elif request_type == 'Delete':
+                      # Do NOT disable encryption-by-default on teardown - that
+                      # is a security regression. Only reset the default key to
+                      # the AWS-managed aws/ebs key, so new volumes stay
+                      # encrypted and nothing points at a CMK pending deletion.
+                      ec2.reset_ebs_default_kms_key_id()
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, PHYSICAL_ID)
+              except Exception as e:
+                  cfnresponse.send(event, context, cfnresponse.FAILED, {'Error': str(e)}, PHYSICAL_ID)
+
+  # CFN invokes the Lambda on Create / Update / Delete. The CmkArn property
+  # supplies the target key and makes the resource re-run if the key changes.
+  EbsEncryptionByDefault:
+    Type: Custom::EbsEncryptionDefault
+    Properties:
+      ServiceToken: !GetAtt EbsEncryptionLambda.Arn
+      CmkArn: !GetAtt ComplianceCmk.Arn
+
+Outputs:
+  ComplianceCmkArn:
+    Description: >-
+      ARN of the compliance baseline CMK. Pass to Layer 1 as the
+      LogsBucketCmkArn parameter to switch the CloudTrail logs bucket to SSE-KMS.
+    Value: !GetAtt ComplianceCmk.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-ComplianceCmkArn"
+
+  ComplianceCmkId:
+    Description: Key ID of the compliance baseline CMK.
+    Value: !Ref ComplianceCmk
+    Export:
+      Name: !Sub "${AWS::StackName}-ComplianceCmkId"
+
+  ComplianceCmkAliasName:
+    Description: Alias of the compliance baseline CMK.
+    Value: !Ref ComplianceCmkAlias
+    Export:
+      Name: !Sub "${AWS::StackName}-ComplianceCmkAliasName"

--- a/cloudformation/03-encryption.yaml
+++ b/cloudformation/03-encryption.yaml
@@ -11,14 +11,24 @@ Description: >-
 Parameters:
   KeyAdministratorRoleArn:
     Type: String
-    AllowedPattern: "arn:aws:iam::[0-9]{12}:role/.+"
-    ConstraintDescription: Must be a full IAM role ARN (arn:aws:iam::<account>:role/<name>).
+    AllowedPattern: "arn:aws[a-z-]*:iam::[0-9]{12}:role/.+"
+    ConstraintDescription: Must be a full IAM role ARN, e.g. arn:aws:iam::<account>:role/<name> (aws-us-gov and aws-cn partitions also accepted).
     Description: >-
       ARN of the IAM role designated to ADMINISTER the CMK. Use the Layer 2
       admin role: <iam-baseline-stack-name>-admin. This role manages the key
       but the Layer 2 AdminPermissionsBoundary still denies ScheduleKeyDeletion
       / DisableKey / DeleteAlias, so it cannot destroy the key. No default -
       the key administrator must be set explicitly on every deploy.
+
+  KeyUserRoleArns:
+    Type: CommaDelimitedList
+    Description: >-
+      Comma-separated IAM role ARNs that need to USE the CMK to read data
+      encrypted under it - at minimum the Layer 2 auditor role
+      (<iam-baseline-stack-name>-auditor), which reads CloudTrail log objects
+      from the SSE-KMS bucket for evidence collection. Granted Decrypt and
+      DescribeKey only - read-only key usage (AC-6). No default - list the
+      reader role(s) explicitly.
 
   KeyAliasName:
     Type: String
@@ -140,6 +150,23 @@ Resources:
               StringEquals:
                 aws:SourceAccount: !Ref AWS::AccountId
 
+          # Statement 4 - designated KEY USERS. The roles that need to READ
+          # data encrypted under the CMK - chiefly the Layer 2 auditor role,
+          # which reads CloudTrail log objects from the SSE-KMS bucket for
+          # evidence collection. Without this, s3:GetObject on an encrypted
+          # log file fails: S3 calls kms:Decrypt as the auditor, whose AWS
+          # managed policies (ReadOnlyAccess / SecurityAudit) do not include
+          # it, and Statement 1 only delegates to IAM. Scoped to Decrypt +
+          # DescribeKey - read-only key usage, no GenerateDataKey (AC-6).
+          - Sid: AllowKeyUsage
+            Effect: Allow
+            Principal:
+              AWS: !Ref KeyUserRoleArns
+            Action:
+              - kms:Decrypt
+              - kms:DescribeKey
+            Resource: "*"
+
   # Alias = a stable, human-readable handle for the key. Templates and callers
   # reference alias/... so the underlying key can be replaced without
   # rewriting every reference.
@@ -154,8 +181,8 @@ Resources:
   # password policy). The pattern: a Lambda-backed custom resource that
   # translates CFN Create / Update / Delete events into EC2 API calls.
   #
-  # Execution role - least privilege: basic Lambda logging plus exactly the
-  # five EBS-encryption verbs.
+  # Execution role - least privilege: basic Lambda logging plus the two
+  # EBS-encryption verbs the handler actually calls.
   EbsEncryptionLambdaRole:
     Type: AWS::IAM::Role
     Properties:
@@ -179,10 +206,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - ec2:EnableEbsEncryptionByDefault
-                  - ec2:GetEbsEncryptionByDefault
                   - ec2:ModifyEbsDefaultKmsKeyId
-                  - ec2:GetEbsDefaultKmsKeyId
-                  - ec2:ResetEbsDefaultKmsKeyId
                 Resource: "*"
 
   EbsEncryptionLambda:
@@ -219,11 +243,13 @@ Resources:
                       # the AWS-managed aws/ebs key (SC-12).
                       ec2.modify_ebs_default_kms_key_id(KmsKeyId=props['CmkArn'])
                   elif request_type == 'Delete':
-                      # Do NOT disable encryption-by-default on teardown - that
-                      # is a security regression. Only reset the default key to
-                      # the AWS-managed aws/ebs key, so new volumes stay
-                      # encrypted and nothing points at a CMK pending deletion.
-                      ec2.reset_ebs_default_kms_key_id()
+                      # No-op. The CMK has DeletionPolicy: Retain, so it
+                      # survives stack teardown and the account EBS default
+                      # can safely keep referencing it. Resetting to the
+                      # AWS-managed aws/ebs key here would be a silent CJIS
+                      # 5.10.1.2 regression; decommissioning the CMK is a
+                      # deliberate, separate action.
+                      pass
                   cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, PHYSICAL_ID)
               except Exception as e:
                   cfnresponse.send(event, context, cfnresponse.FAILED, {'Error': str(e)}, PHYSICAL_ID)


### PR DESCRIPTION
## Summary
- Customer-managed KMS CMK (`cloudformation/03-encryption.yaml`) with annual rotation and a four-statement key policy: the `root`/`kms:*` IAM-delegation switch, an explicitly designated key administrator (the Layer 2 admin role), CloudTrail as a key user for SSE-KMS log writes, and the Layer 2 auditor role as a key user with `kms:Decrypt` so audit evidence stays readable after the log bucket switches to SSE-KMS
- Account-level EBS encryption-by-default via a Lambda-backed `Custom::EbsEncryptionDefault` resource — there is no native CloudFormation type (the same gap Layer 2 hit with the IAM password policy); a fixed physical resource ID keeps Updates stable, and stack teardown is a deliberate no-op so the Retained CMK keeps protecting existing volumes
- `DeletionPolicy: Retain` on the CMK — deleting or replacing a key permanently destroys all data encrypted under it
- Wires the CMK into Layer 1: `01-logging.yaml` gains a `LogsBucketCmkArn` parameter and `UseCmkForLogsBucket` condition; the CloudTrail log bucket switches to SSE-KMS (with S3 Bucket Keys) when the ARN is supplied, SSE-S3 otherwise. The two-pass deploy breaks the cycle — Layer 1 is numbered first but its encryption key is created in Layer 3
- Full README refresh: the README had been stale since before Layer 1 — added Layers 1/2/3 to the control tables, architecture diagram, repository structure, AWS services list, and deployment steps, and corrected the SCP filenames left wrong by the earlier file-structure refactor

## Controls Addressed
- SC-12: agency-managed CMK with annual rotation — full control of the key establishment and management lifecycle
- SC-13: KMS performs cryptographic operations in FIPS 140-validated HSMs
- SC-28 / SC-28(1): encryption of data at rest — CloudTrail logs (S3 SSE-KMS) and EBS volumes, both under the CMK
- CJIS v6.0 5.10.1.2: agency-managed key for CJI at rest; an AWS-managed key would place AWS personnel within CJIS scope

> **Design note — key administration trade-off:** the key policy keeps the standard `root`/`kms:*` IAM-delegation statement (removing it is an AWS-documented orphan-key anti-pattern). The designated key administrator (Layer 2 admin role) is the auditable record of who governs the key; because Statement 1 delegates to IAM, full admin/use separation would require narrowing the root statement. What is hard-enforced regardless of IAM: the Layer 2 `AdminPermissionsBoundary` denies `kms:ScheduleKeyDeletion` / `DisableKey` / `DeleteAlias`, so the key administrator cannot destroy the key.

## Test Plan
- [x] `cfn-lint` clean on `03-encryption.yaml` and `01-logging.yaml` — no findings
- [x] `aws cloudformation validate-template` passes for both templates
- [x] Self-review: three-angle diff review pass; 5 findings applied (auditor `kms:Decrypt` grant, EBS-teardown no-op, GovCloud-safe ARN pattern, two README corrections)
- [ ] Deploy Layer 3 → `aws kms get-key-rotation-status` shows rotation enabled — static-verified (`EnableKeyRotation: true`); live-deploy deferred
- [ ] Re-deploy Layer 1 with the CMK ARN → CloudTrail log bucket reports SSE-KMS — static-verified (conditional `BucketEncryption` driven by `UseCmkForLogsBucket`); live-deploy deferred
- [ ] `aws ec2 get-ebs-encryption-by-default` returns enabled with the CMK as default — static-verified (custom-resource logic); live-deploy deferred (mutates the account-wide EBS encryption default)
- [ ] CloudTrail delivers logs to the SSE-KMS bucket and the auditor role can read them back — static-verified (key policy Statements 3 and 4); live-deploy deferred

> **Validation note:** offline validation complete — `cfn-lint` and `aws cloudformation validate-template` both pass. Deploy-dependent items are static-verified against template logic, not runtime-proven. Live deploy deferred, consistent with Layers 1–2: the only available account is the Organizations management account, not a sandbox, and Layer 3 mutates account-wide settings (the EBS encryption default).

Closes #4
Closes 0XBN-56
