### PR TITLE
feat: Layer 4 — AWS Config + 5 managed compliance rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ graph TD
     ACC --> L1["Layer 1 (01-logging.yaml)<br/>CloudTrail + Object Lock S3 + VPC Flow Logs"]
     ACC --> L2["Layer 2 (02-iam-baseline.yaml)<br/>Password Policy + Auditor and Admin Roles"]
     ACC --> L3["Layer 3 (03-encryption.yaml)<br/>KMS CMK + EBS Default Encryption"]
+    ACC --> L4["Layer 4 (04-config.yaml)<br/>Config Recorder + Compliance Rules"]
     ACC --> SB["secure-bucket.yaml<br/>Secure S3 Bucket"]
     L3 -. exports CMK ARN .-> L1
+    L3 -. exports CMK ARN .-> L4
 ```
 
-SCPs are attached at the Organization Root, enforcing preventive guardrails across all accounts. These policies override IAM permissions, including administrator access, so non-compliant actions are blocked before they happen. CloudFormation templates are deployed into member accounts as numbered layers (`01` → `02` → `03`), each building on the previous, to provision resources that meet security baselines without manual configuration. Together, they create a defense-in-depth model where organization-level policies and account-level infrastructure work in tandem.
+SCPs are attached at the Organization Root, enforcing preventive guardrails across all accounts. These policies override IAM permissions, including administrator access, so non-compliant actions are blocked before they happen. CloudFormation templates are deployed into member accounts as numbered layers (`01` → `02` → `03` → `04`), each building on the previous, to provision resources that meet security baselines without manual configuration. Together, they create a defense-in-depth model where organization-level policies and account-level infrastructure work in tandem.
 
 ## Compliance Frameworks
 
@@ -59,6 +61,7 @@ The [Federal Risk and Authorization Management Program (FedRAMP)](https://www.fe
 | Layer 1 — Logging and Monitoring | `cloudformation/01-logging.yaml` | CloudFormation (IaC) | Multi-region CloudTrail, an Object Lock (COMPLIANCE mode) log bucket, a CloudWatch log group, and VPC Flow Logs | Audit and Accountability |
 | Layer 2 — IAM Baseline | `cloudformation/02-iam-baseline.yaml` | CloudFormation (IaC) | Account password policy, a read-only auditor role, and an MFA + ExternalId admin role capped by a permissions boundary | Identity and Least Privilege |
 | Layer 3 — Encryption | `cloudformation/03-encryption.yaml` | CloudFormation (IaC) | Customer-managed KMS CMK with annual rotation, a separated key policy, and account-level EBS encryption-by-default | Data Protection at Rest |
+| Layer 4 — Configuration & Compliance | `cloudformation/04-config.yaml` | CloudFormation (IaC) | AWS Config recorder + delivery channel + dedicated SSE-KMS bucket, plus five managed Config Rules continuously validating Layers 1–3 | Continuous Compliance Monitoring |
 | Secure S3 Bucket | `cloudformation/secure-bucket.yaml` | CloudFormation (IaC) | An S3 bucket with all public access blocked and AES256 server-side encryption | Secure by Default |
 
 ## Compliance Framework Mapping
@@ -75,6 +78,7 @@ Each control was selected to address specific compliance requirements across CJI
 | Layer 1 — Logging and Monitoring | AU-2 (Event Logging), AU-3 (Content of Audit Records), AU-9, AU-12 | AU-2 (L/M/H), AU-3 (L/M/H), AU-9 (L/M/H), AU-12 (L/M/H) | AU-2 (Event Logging), AU-3 (Content of Audit Records), AU-9 (Protection of Audit Information), AU-12 (Audit Record Generation) |
 | Layer 2 — IAM Baseline | AC-2 (Account Management), AC-3 (Access Enforcement), AC-6 (Least Privilege), IA-5 (Authenticator Management) | AC-2 (L/M/H), AC-3 (L/M/H), AC-6 (M/H), IA-5 (L/M/H) | AC-2 (Account Management), AC-3 (Access Enforcement), AC-6 (Least Privilege), IA-5 (Authenticator Management) |
 | Layer 3 — Encryption | SC-12 (Cryptographic Key Management), SC-13 (Cryptographic Protection), SC-28, SC-28(1) | SC-12 (L/M/H), SC-13 (L/M/H), SC-28 (M/H), SC-28(1) (M/H) | SC-12 (Cryptographic Key Establishment and Management), SC-13 (Cryptographic Protection), SC-28 (Protection of Information at Rest), SC-28(1) (Cryptographic Protection) |
+| Layer 4 — Configuration & Compliance | CM-2 (Baseline Configuration), CM-6 (Configuration Settings), CM-8 (System Component Inventory) | CM-2 (L/M/H), CM-6 (L/M/H), CM-8 (L/M/H) | CM-2 (Baseline Configuration), CM-6 (Configuration Settings), CM-8 (System Component Inventory) |
 | Secure S3 Bucket | SC-28 (Protection of Information at Rest), AC-3 (Access Enforcement) | SC-28 (M/H), AC-3 (L/M/H) | SC-28 (Protection of Information at Rest), AC-3 (Access Enforcement) |
 
 > **Note:** CJIS v6.0 now uses NIST 800-53 control identifiers directly, so the CJIS and NIST columns share the same control IDs. The distinction is that CJIS scopes these requirements specifically to Criminal Justice Information (CJI), while NIST 800-53 applies broadly to federal information systems.
@@ -89,6 +93,7 @@ aws-compliance-as-code/
 │   ├── 01-logging.yaml                 # Layer 1: CloudTrail + Object Lock S3 + CloudWatch + VPC Flow Logs
 │   ├── 02-iam-baseline.yaml            # Layer 2: IAM password policy + auditor/admin roles
 │   ├── 03-encryption.yaml              # Layer 3: KMS CMK + alias + EBS encryption-by-default
+│   ├── 04-config.yaml                  # Layer 4: AWS Config recorder + delivery channel + 5 managed rules
 │   └── secure-bucket.yaml              # Standalone: secure S3 bucket (public access block + AES256)
 ├── scps/
 │   ├── scp-deny-audit-log-deletion.json            # SCP: Deny CloudTrail DeleteTrail / StopLogging
@@ -100,7 +105,7 @@ aws-compliance-as-code/
 └── README.md
 ```
 
-The numbered CloudFormation prefixes (`01`–`03`) indicate deployment order; each layer builds on the one before it.
+The numbered CloudFormation prefixes (`01`–`04`) indicate deployment order; each layer builds on the one before it.
 
 ## AWS Services Used
 
@@ -111,6 +116,7 @@ The numbered CloudFormation prefixes (`01`–`03`) indicate deployment order; ea
 - **[AWS IAM](https://aws.amazon.com/iam/)**: Password policy, scoped roles, and permissions boundary (Layer 2)
 - **[Amazon S3](https://aws.amazon.com/s3/)**: Object Lock log storage and the secure bucket baseline
 - **[Amazon EBS](https://aws.amazon.com/ebs/)**: Account-level encryption-by-default for new volumes (Layer 3)
+- **[AWS Config](https://aws.amazon.com/config/)**: Continuous configuration recording + five managed Config Rules for compliance evaluation (Layer 4)
 - **[Amazon CloudWatch Logs](https://aws.amazon.com/cloudwatch/)**: Hot, queryable copy of CloudTrail and VPC Flow Log events
 - **[AWS Lambda](https://aws.amazon.com/lambda/)**: Backs the custom resources for account settings with no native CloudFormation type
 - **[AWS CLI](https://aws.amazon.com/cli/)**: Interface for deploying SCPs and CloudFormation stacks
@@ -123,7 +129,7 @@ SCPs are attached at the Organization Root and act as permission boundaries that
 
 ### CloudFormation (Compliant by Default)
 
-CloudFormation templates encode security requirements directly into resource definitions, so resources deploy in their intended secure state every time, eliminating configuration drift and manual misconfiguration. The templates are organized as numbered layers (`01-logging.yaml` → `02-iam-baseline.yaml` → `03-encryption.yaml`) that build on one another — Layer 3's KMS key, for example, is exported and adopted by Layer 1's CloudTrail log bucket. Each template is auditable documentation of the intended secure state.
+CloudFormation templates encode security requirements directly into resource definitions, so resources deploy in their intended secure state every time, eliminating configuration drift and manual misconfiguration. The templates are organized as numbered layers (`01-logging.yaml` → `02-iam-baseline.yaml` → `03-encryption.yaml` → `04-config.yaml`) that build on one another — Layer 3's KMS key, for example, is exported and adopted by both Layer 1's CloudTrail log bucket and Layer 4's Config delivery-channel bucket; Layer 4's managed Config Rules then continuously verify that Layers 1–3 stay compliant. Each template is auditable documentation of the intended secure state.
 
 ### Defense in Depth
 
@@ -304,6 +310,17 @@ aws cloudformation deploy \
     --parameter-overrides DefaultVpcId=<DEFAULT_VPC_ID> \
         LogsBucketCmkArn=$(aws cloudformation describe-stacks \
         --stack-name compliance-layer3-encryption \
+        --query "Stacks[0].Outputs[?OutputKey=='ComplianceCmkArn'].OutputValue" --output text)
+```
+
+**Layer 4 — Configuration & Compliance.** Pass the Layer 3 CMK ARN as the bucket encryption key. Deploy this after the Layer 1 second pass so the Config rules evaluate against the final SSE-KMS state.
+
+```
+aws cloudformation deploy \
+    --stack-name compliance-layer4-config \
+    --template-file cloudformation/04-config.yaml \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --parameter-overrides ConfigCmkArn=$(aws cloudformation describe-stacks --stack-name compliance-layer3-encryption \
         --query "Stacks[0].Outputs[?OutputKey=='ComplianceCmkArn'].OutputValue" --output text)
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The [Federal Risk and Authorization Management Program (FedRAMP)](https://www.fe
 | Layer 1 — Logging and Monitoring | `cloudformation/01-logging.yaml` | CloudFormation (IaC) | Multi-region CloudTrail, an Object Lock (COMPLIANCE mode) log bucket, a CloudWatch log group, and VPC Flow Logs | Audit and Accountability |
 | Layer 2 — IAM Baseline | `cloudformation/02-iam-baseline.yaml` | CloudFormation (IaC) | Account password policy, a read-only auditor role, and an MFA + ExternalId admin role capped by a permissions boundary | Identity and Least Privilege |
 | Layer 3 — Encryption | `cloudformation/03-encryption.yaml` | CloudFormation (IaC) | Customer-managed KMS CMK with annual rotation, a separated key policy, and account-level EBS encryption-by-default | Data Protection at Rest |
-| Layer 4 — Configuration & Compliance | `cloudformation/04-config.yaml` | CloudFormation (IaC) | AWS Config recorder + delivery channel + dedicated SSE-KMS bucket, plus five managed Config Rules continuously validating Layers 1–3 | Continuous Compliance Monitoring |
+| Layer 4 — Configuration & Compliance | `cloudformation/04-config.yaml` | CloudFormation (IaC) | AWS Config recorder + delivery channel + dedicated SSE-KMS Object-Lock bucket, plus six managed Config Rules continuously validating Layers 1–3 | Continuous Compliance Monitoring |
 | Secure S3 Bucket | `cloudformation/secure-bucket.yaml` | CloudFormation (IaC) | An S3 bucket with all public access blocked and AES256 server-side encryption | Secure by Default |
 
 ## Compliance Framework Mapping
@@ -93,7 +93,7 @@ aws-compliance-as-code/
 │   ├── 01-logging.yaml                 # Layer 1: CloudTrail + Object Lock S3 + CloudWatch + VPC Flow Logs
 │   ├── 02-iam-baseline.yaml            # Layer 2: IAM password policy + auditor/admin roles
 │   ├── 03-encryption.yaml              # Layer 3: KMS CMK + alias + EBS encryption-by-default
-│   ├── 04-config.yaml                  # Layer 4: AWS Config recorder + delivery channel + 5 managed rules
+│   ├── 04-config.yaml                  # Layer 4: AWS Config recorder + delivery channel + 6 managed rules
 │   └── secure-bucket.yaml              # Standalone: secure S3 bucket (public access block + AES256)
 ├── scps/
 │   ├── scp-deny-audit-log-deletion.json            # SCP: Deny CloudTrail DeleteTrail / StopLogging
@@ -116,7 +116,7 @@ The numbered CloudFormation prefixes (`01`–`04`) indicate deployment order; ea
 - **[AWS IAM](https://aws.amazon.com/iam/)**: Password policy, scoped roles, and permissions boundary (Layer 2)
 - **[Amazon S3](https://aws.amazon.com/s3/)**: Object Lock log storage and the secure bucket baseline
 - **[Amazon EBS](https://aws.amazon.com/ebs/)**: Account-level encryption-by-default for new volumes (Layer 3)
-- **[AWS Config](https://aws.amazon.com/config/)**: Continuous configuration recording + five managed Config Rules for compliance evaluation (Layer 4)
+- **[AWS Config](https://aws.amazon.com/config/)**: Continuous configuration recording + six managed Config Rules for compliance evaluation (Layer 4)
 - **[Amazon CloudWatch Logs](https://aws.amazon.com/cloudwatch/)**: Hot, queryable copy of CloudTrail and VPC Flow Log events
 - **[AWS Lambda](https://aws.amazon.com/lambda/)**: Backs the custom resources for account settings with no native CloudFormation type
 - **[AWS CLI](https://aws.amazon.com/cli/)**: Interface for deploying SCPs and CloudFormation stacks
@@ -264,7 +264,7 @@ Example output:
 
 ### Step 3: Deploy the CloudFormation Layers
 
-Deploy the numbered templates in order — each layer builds on the previous. All three layers create IAM resources, so `CAPABILITY_NAMED_IAM` is required. (`secure-bucket.yaml` is a standalone foundational template and can be deployed independently.)
+Deploy the numbered templates in order — each layer builds on the previous. All four layers create IAM resources, so `CAPABILITY_NAMED_IAM` is required (the flag covers both named and unnamed roles). (`secure-bucket.yaml` is a standalone foundational template and can be deployed independently.)
 
 **Layer 1 — Logging & Monitoring.** Leave `LogsBucketCmkArn` unset for now; the CloudTrail log bucket uses SSE-S3 until the Layer 3 CMK exists.
 
@@ -313,7 +313,7 @@ aws cloudformation deploy \
         --query "Stacks[0].Outputs[?OutputKey=='ComplianceCmkArn'].OutputValue" --output text)
 ```
 
-**Layer 4 — Configuration & Compliance.** Pass the Layer 3 CMK ARN as the bucket encryption key. Deploy this after the Layer 1 second pass so the Config rules evaluate against the final SSE-KMS state.
+**Layer 4 — Configuration & Compliance.** Pass the Layer 3 CMK ARN; the CMK and the Config bucket must be in the same region. Deploy after the Layer 1 second pass so the rules evaluate against the final SSE-KMS state. **If the account already has AWS Config enabled in this region** (Control Tower, console-onboarding, or a prior stack), add `ManageConfigService=UseExisting` to the overrides — the stack then creates only the six Config Rules, which evaluate against the existing recorder.
 
 ```
 aws cloudformation deploy \
@@ -388,7 +388,7 @@ This project demonstrates the core GRC Engineering skill of translating complian
 
 The controls illustrate a range of enforcement patterns — action-scoped denials (CloudTrail log deletion), principal-scoped denials (root-user lockdown via `NotAction` plus an `aws:PrincipalArn` condition), region-conditioned rules (network changes confined to approved regions), and encryption mandates (S3 uploads required to use SSE-KMS) — alongside a layered, compliant-by-default CloudFormation baseline. Together they demonstrate the flexibility of SCPs and infrastructure-as-code as compliance enforcement mechanisms.
 
-This foundation positions the project for expansion into CI/CD pipeline guardrails, AWS Config rules for continuous compliance monitoring, drift remediation automation, and multi-account architectures with OU-scoped policies.
+This foundation positions the project for expansion into CI/CD pipeline guardrails, GuardDuty / Security Hub detection (planned Layer 5), drift-remediation automation, and multi-account architectures with OU-scoped policies.
 
 ## References
 

--- a/cloudformation/04-config.yaml
+++ b/cloudformation/04-config.yaml
@@ -2,24 +2,49 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: >-
   Layer 4 - Configuration & Compliance. Enables AWS Config (configuration
   recorder + delivery channel + dedicated S3 bucket encrypted with the Layer 3
-  CMK) and deploys five managed Config Rules that continuously verify the
+  CMK) and deploys six managed Config Rules that continuously verify the
   baselines established in Layers 1-3: multi-region CloudTrail, S3 default
-  encryption, the account password policy, encrypted EBS volumes, and the
-  SSH-port restriction. Where CloudTrail captures "who called the API,"
-  Config captures "what does every resource currently look like" - the state
-  half of the evidence story. Satisfies NIST 800-53 Rev 5 CM-2, CM-6, CM-8;
-  CJIS v6.0 5.10.4.1.
+  encryption (both the lax SSE-S3-OR-KMS check and the strict SSE-KMS check),
+  the account password policy, encrypted EBS volumes, and the SSH-port
+  restriction. Where CloudTrail captures "who called the API," Config captures
+  "what does every resource currently look like" - the state half of the
+  evidence story. The recorder, channel, bucket, and role are CONDITIONAL on
+  the ManageConfigService parameter: pass UseExisting when the account already
+  has AWS Config enabled in this region (Control Tower, console-onboarding,
+  another stack) and only the rules are created, evaluating against the
+  existing recorder. Satisfies NIST 800-53 Rev 5 CM-2, CM-6, CM-8; CJIS v6.0
+  5.10.4.1.
 
 Parameters:
   ConfigCmkArn:
     Type: String
     AllowedPattern: "arn:aws[a-z-]*:kms:[a-z0-9-]+:[0-9]{12}:key/.+"
-    ConstraintDescription: Must be a full KMS key ARN, e.g. arn:aws:kms:<region>:<account>:key/<uuid>.
+    ConstraintDescription: Must be a full KMS key ARN.
     Description: >-
       ARN of the Layer 3 compliance CMK (03-encryption.yaml output
-      ComplianceCmkArn). Encrypts the Config delivery-channel S3 bucket with
-      the agency-managed key (SC-28 / CJIS 5.10.1.2). Required - this layer
-      runs after Layer 3, so there is no SSE-S3 fallback.
+      ComplianceCmkArn). Encrypts the Config delivery bucket with the
+      agency-managed key (SC-28 / CJIS 5.10.1.2). The CMK MUST be in the
+      same AWS region as this stack: S3 SSE-KMS requires a same-region key,
+      so passing a cross-region ARN fails bucket creation with
+      KMS.NotFoundException. Required even when ManageConfigService=
+      UseExisting (the value is unused in that mode but CFN still requires
+      it to satisfy the AllowedPattern - pass any agency CMK ARN).
+
+  ManageConfigService:
+    Type: String
+    Default: Provision
+    AllowedValues:
+      - Provision
+      - UseExisting
+    Description: >-
+      Whether to create the ConfigurationRecorder, DeliveryChannel, recorder
+      role, and delivery bucket. AWS Config allows exactly ONE recorder and
+      ONE delivery channel per region per account; attempting Provision in an
+      account that already has Config enabled (Control Tower, Security Hub
+      auto-enable, prior stack, console-onboarding) raises
+      MaxNumberOfConfigurationRecordersExceededException. Pass UseExisting in
+      that case and only the rules are created - they evaluate against the
+      existing recorder, regardless of where it was provisioned.
 
   ConfigSnapshotDeliveryFrequency:
     Type: String
@@ -33,18 +58,28 @@ Parameters:
     Description: >-
       Cadence at which Config delivers a full configuration snapshot to the
       S3 bucket. Change events are recorded continuously regardless; this
-      controls only the periodic snapshot. Twelve_Hours is the conservative
-      balance between evidence currency and S3 / KMS API cost.
+      controls only the periodic snapshot.
+
+  ConfigBucketObjectLockDays:
+    Type: Number
+    Default: 365
+    MinValue: 1
+    Description: >-
+      Object Lock retention applied in COMPLIANCE mode to every object in the
+      Config bucket. Matches Layer 1's CloudTrail-bucket pattern: even the
+      root user cannot shorten or delete objects within the retention window
+      (AU-9 / CM-8 evidence integrity). 365 is the FedRAMP High AU-11 floor.
 
   PasswordPolicyMinLength:
     Type: Number
     Default: 14
-    MinValue: 8
+    MinValue: 14
     MaxValue: 128
     Description: >-
       Minimum password length the iam-password-policy Config rule asserts.
-      Should match the Layer 2 PasswordPolicy custom-resource value (default
-      14) so the rule checks the same baseline the policy enforces.
+      Floor is 14 to match Layer 2's PasswordPolicyLambda floor - the two
+      layers cannot diverge below the FedRAMP High / CJIS AAL2 baseline
+      without a coordinated change in both templates.
 
   PasswordPolicyMaxAge:
     Type: Number
@@ -52,8 +87,8 @@ Parameters:
     MinValue: 1
     MaxValue: 1095
     Description: >-
-      Maximum password age (days) the iam-password-policy Config rule asserts.
-      Match Layer 2 (default 90).
+      Maximum password age (days) the iam-password-policy Config rule
+      asserts. Match Layer 2's MaxPasswordAgeInDays (default 90).
 
   PasswordPolicyReusePrevention:
     Type: Number
@@ -64,19 +99,73 @@ Parameters:
       Password reuse-prevention count the iam-password-policy Config rule
       asserts. Match Layer 2 (default 24).
 
+  PasswordPolicyRequireUppercase:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: >-
+      Whether the iam-password-policy rule asserts uppercase required.
+      Mirror the Layer 2 PasswordPolicy RequireUppercaseCharacters value so
+      the rule does not report NON_COMPLIANT against a policy Layer 2
+      legitimately applied, and cannot silently certify a weaker policy.
+
+  PasswordPolicyRequireLowercase:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: >-
+      Whether the iam-password-policy rule asserts lowercase required.
+      Mirror Layer 2's RequireLowercaseCharacters.
+
+  PasswordPolicyRequireSymbols:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: >-
+      Whether the iam-password-policy rule asserts symbols required.
+      Mirror Layer 2's RequireSymbols.
+
+  PasswordPolicyRequireNumbers:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: >-
+      Whether the iam-password-policy rule asserts numbers required.
+      Mirror Layer 2's RequireNumbers.
+
+Conditions:
+  # Whether this stack provisions the Config recorder, channel, role, and
+  # bucket. Set to UseExisting when Config is already enabled in the region
+  # to deploy only the rules, which then evaluate against the existing
+  # recorder.
+  ProvisionConfigService: !Equals [!Ref ManageConfigService, "Provision"]
+
 Resources:
 
   # S3 bucket holding Config snapshots, configuration history, and delivery
-  # records. Same hardening philosophy as the Layer 1 CloudTrail bucket:
-  # public access blocked, versioned (a poisoned overwrite is recoverable),
-  # SSE-KMS with the agency-managed CMK, DeletionPolicy Retain to outlive a
-  # stack teardown - the configuration history is the CM-8 inventory record.
+  # records. Same hardening as the Layer 1 CloudTrail bucket: Object Lock
+  # COMPLIANCE mode for immutability (the configuration history IS the CM-8
+  # inventory record, equivalent to AU-9 evidence), versioning, SSE-KMS with
+  # the agency-managed CMK, all public access blocked, DeletionPolicy Retain
+  # to outlive a stack teardown. Bucket name includes the region so the
+  # stack can be deployed in multiple regions without name collisions.
   ConfigBucket:
     Type: AWS::S3::Bucket
+    Condition: ProvisionConfigService
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
-      BucketName: !Sub "aws-config-${AWS::AccountId}"
+      BucketName: !Sub "aws-config-${AWS::Region}-${AWS::AccountId}"
+      ObjectLockEnabled: true
+      ObjectLockConfiguration:
+        ObjectLockEnabled: Enabled
+        Rule:
+          DefaultRetention:
+            # COMPLIANCE mode: even the root account cannot shorten or
+            # delete an object within the retention window. This is what
+            # turns the bucket into immutable evidence storage.
+            Mode: COMPLIANCE
+            Days: !Ref ConfigBucketObjectLockDays
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
@@ -92,15 +181,22 @@ Resources:
             # CloudTrail bucket takes after the second-pass deploy.
             BucketKeyEnabled: true
       VersioningConfiguration:
+        # Required for Object Lock; preserves prior versions of any
+        # accidentally-overwritten delivery object.
         Status: Enabled
 
   # Bucket policy: lets the Config service write delivery objects under the
-  # AWSLogs/<account>/Config/ prefix, denies deletion of those objects, and
-  # denies any unencrypted access. The aws:SourceAccount condition is the
-  # confused-deputy guard for the service-principal grants - matches the
-  # pattern Layer 1 uses for CloudTrail.
+  # AWSLogs/<account>/Config/ prefix, denies bucket-wide object deletion
+  # (any object in the bucket - matching Layer 1's pattern, not just the
+  # delivery prefix), and denies any unencrypted access. No x-amz-acl
+  # condition: new S3 buckets default to BucketOwnerEnforced (April 2023+)
+  # which rejects any request carrying an ACL header, and AWS Config has
+  # been updated to omit the header for those buckets. Authorization
+  # relies on the bucket-policy grant + aws:SourceAccount confused-deputy
+  # guard.
   ConfigBucketPolicy:
     Type: AWS::S3::BucketPolicy
+    Condition: ProvisionConfigService
     Properties:
       Bucket: !Ref ConfigBucket
       PolicyDocument:
@@ -132,15 +228,14 @@ Resources:
             Resource: !Sub "${ConfigBucket.Arn}/AWSLogs/${AWS::AccountId}/Config/*"
             Condition:
               StringEquals:
-                s3:x-amz-acl: bucket-owner-full-control
                 aws:SourceAccount: !Ref AWS::AccountId
-          - Sid: DenyDeliveryObjectDeletion
+          - Sid: DenyObjectDeletion
             Effect: Deny
             Principal: "*"
             Action:
               - s3:DeleteObject
               - s3:DeleteObjectVersion
-            Resource: !Sub "${ConfigBucket.Arn}/AWSLogs/${AWS::AccountId}/Config/*"
+            Resource: !Sub "${ConfigBucket.Arn}/*"
           - Sid: DenyInsecureTransport
             Effect: Deny
             Principal: "*"
@@ -152,15 +247,14 @@ Resources:
               Bool:
                 aws:SecureTransport: "false"
 
-  # IAM role the Config recorder assumes. The AWS-managed AWS_ConfigRole
-  # supplies Describe* / List* across services so Config can read every
-  # resource's state; the inline policy adds the write path (S3 PutObject
-  # under the delivery prefix) and KMS access on the Layer 3 CMK so the
-  # SSE-KMS PUT succeeds. The CMK's key policy delegates to IAM via its
-  # Statement 1 (account root, kms:*), so this IAM grant is what actually
-  # opens the door - no change to Layer 3's key policy is required.
+  # IAM role the Config recorder assumes. AWS-managed AWS_ConfigRole for
+  # cross-service reads + an inline policy for delivery-bucket writes and
+  # KMS access on the CMK. The trust policy adds aws:SourceAccount as a
+  # confused-deputy guard for the service-principal grant - the same
+  # pattern the bucket policy uses.
   ConfigRecorderRole:
     Type: AWS::IAM::Role
+    Condition: ProvisionConfigService
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -169,6 +263,9 @@ Resources:
             Principal:
               Service: config.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWS_ConfigRole
       Policies:
@@ -180,9 +277,6 @@ Resources:
                 Effect: Allow
                 Action: s3:PutObject
                 Resource: !Sub "${ConfigBucket.Arn}/AWSLogs/${AWS::AccountId}/Config/*"
-                Condition:
-                  StringEquals:
-                    s3:x-amz-acl: bucket-owner-full-control
               - Sid: ReadBucketMetadata
                 Effect: Allow
                 Action:
@@ -198,63 +292,71 @@ Resources:
                 Resource: !Ref ConfigCmkArn
 
   # The configuration recorder. RecordingGroup.AllSupported with
-  # IncludeGlobalResourceTypes true is the CM-8 ("system component
-  # inventory") engine: every supported resource type, including global
-  # ones (IAM, CloudFront, Route 53), becomes a configuration item on
-  # every change. One recorder per region per account is the AWS limit.
+  # IncludeGlobalResourceTypes is the CM-8 inventory engine. One recorder
+  # per region per account is the AWS limit - if Config is already enabled
+  # in this region, set ManageConfigService=UseExisting at the parameter
+  # level to skip provisioning. Stack-name-prefixed Name avoids coincidental
+  # collision with the "default" name used by console / Control Tower.
   ConfigRecorder:
     Type: AWS::Config::ConfigurationRecorder
+    Condition: ProvisionConfigService
     Properties:
-      Name: default
+      Name: !Sub "${AWS::StackName}-recorder"
       RoleARN: !GetAtt ConfigRecorderRole.Arn
       RecordingGroup:
         AllSupported: true
         IncludeGlobalResourceTypes: true
 
-  # The delivery channel sends snapshots to the bucket on the configured
-  # cadence. KEY ORDERING DETAIL: Config does not actually START recording
-  # until a delivery channel exists - so the recorder + channel are two
-  # CFN resources but conceptually one running system. DependsOn is needed
-  # because neither references the other directly and CFN cannot otherwise
-  # infer the ordering.
+  # The delivery channel sends snapshots to the bucket. ORDERING: Config
+  # does not start recording until a delivery channel exists, AND the
+  # channel validates write access to the bucket on creation. DependsOn
+  # must cover BOTH the recorder (so the recorder exists when the channel
+  # is wired) AND the bucket policy (so the channel's write-access
+  # validation passes - the implicit !Ref-on-bucket dependency alone does
+  # not guarantee the policy is attached yet).
   ConfigDeliveryChannel:
     Type: AWS::Config::DeliveryChannel
-    DependsOn: ConfigRecorder
+    Condition: ProvisionConfigService
+    DependsOn:
+      - ConfigRecorder
+      - ConfigBucketPolicy
     Properties:
-      Name: default
+      Name: !Sub "${AWS::StackName}-channel"
       S3BucketName: !Ref ConfigBucket
       ConfigSnapshotDeliveryProperties:
         DeliveryFrequency: !Ref ConfigSnapshotDeliveryFrequency
 
   # ---------------------------------------------------------------------
-  # Config Rules - each verifies a specific Layer 1-3 baseline.
-  # Each is a managed AWS rule referenced by Source.SourceIdentifier;
-  # change-triggered rules need the recorder to be capturing the relevant
-  # resource type (covered by AllSupported above) and set Scope.
+  # Config Rules - each verifies a Layer 1-3 baseline. No DependsOn on
+  # the recorder/channel: rules can be created standalone and evaluate
+  # against whatever recorder is running in the region (this stack's, or
+  # a pre-existing one when ManageConfigService=UseExisting). Periodic
+  # rules set MaximumExecutionFrequency: One_Hour for tight detection -
+  # the default is TwentyFour_Hours, which would leave a full-day blind
+  # spot on the trail / password-policy checks.
   # ---------------------------------------------------------------------
 
   # Verifies Layer 1: at least one multi-region trail is enabled and is
-  # logging. Periodic rule (no resource scope - the check is account-level).
+  # logging. Periodic rule.
   MultiRegionCloudTrailRule:
     Type: AWS::Config::ConfigRule
-    DependsOn: ConfigDeliveryChannel
     Properties:
       ConfigRuleName: multi-region-cloudtrail-enabled
       Description: Verifies at least one multi-region CloudTrail is enabled (CM-6, Layer 1).
+      MaximumExecutionFrequency: One_Hour
       Source:
         Owner: AWS
         SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED
 
-  # Verifies Layers 1 and 3: every S3 bucket has default encryption enabled.
-  # Change-triggered on AWS::S3::Bucket. Before Layer 3's second pass the
-  # CloudTrail bucket reports COMPLIANT under SSE-S3; after the second pass
-  # it reports COMPLIANT under SSE-KMS with the CMK.
+  # Verifies S3 buckets have SOME default encryption enabled (SSE-S3 or
+  # SSE-KMS). Lax check - passes on AWS-managed AES256 too. Paired with
+  # the strict S3KmsEncryptionRule below for the CJIS agency-managed-key
+  # story.
   S3EncryptionEnabledRule:
     Type: AWS::Config::ConfigRule
-    DependsOn: ConfigDeliveryChannel
     Properties:
       ConfigRuleName: s3-bucket-server-side-encryption-enabled
-      Description: Verifies S3 buckets have default encryption enabled (CM-6, Layer 1 / 3).
+      Description: Verifies S3 buckets have default encryption enabled (CM-6, lax check).
       Source:
         Owner: AWS
         SourceIdentifier: S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED
@@ -262,39 +364,53 @@ Resources:
         ComplianceResourceTypes:
           - AWS::S3::Bucket
 
-  # Verifies Layer 2: the account password policy meets the baseline.
-  # InputParameters mirror Layer 2's PasswordPolicy custom resource so the
-  # rule checks exactly what was enforced - the values must stay in sync.
-  # Periodic rule (no resource scope - the policy is account-level).
+  # Strict CJIS check: S3 buckets must use SSE-KMS (not SSE-S3 / AES256).
+  # The AWS-managed aws/s3 key does not satisfy CJIS 5.10.1.2's
+  # agency-managed-key requirement; this rule surfaces any bucket relying
+  # on it. The secure-bucket.yaml legacy template and the pre-second-pass
+  # Layer 1 bucket will report NON_COMPLIANT here - that is the intended
+  # signal.
+  S3KmsEncryptionRule:
+    Type: AWS::Config::ConfigRule
+    Properties:
+      ConfigRuleName: s3-default-encryption-kms
+      Description: Verifies S3 buckets default to SSE-KMS (CJIS 5.10.1.2 - agency-managed key).
+      Source:
+        Owner: AWS
+        SourceIdentifier: S3_DEFAULT_ENCRYPTION_KMS
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::S3::Bucket
+
+  # Verifies Layer 2: account password policy meets the baseline. Periodic.
+  # InputParameters mirror Layer 2's PasswordPolicy custom resource via
+  # template parameters so a future toggle in Layer 2 either gets reflected
+  # here at the same time (coordinated change) or surfaces a Config
+  # NON_COMPLIANT - never a silent drift.
   IamPasswordPolicyRule:
     Type: AWS::Config::ConfigRule
-    DependsOn: ConfigDeliveryChannel
     Properties:
       ConfigRuleName: iam-password-policy
       Description: Verifies the account password policy matches the Layer 2 baseline (CM-6 / IA-5).
+      MaximumExecutionFrequency: One_Hour
       Source:
         Owner: AWS
         SourceIdentifier: IAM_PASSWORD_POLICY
-      # InputParameters is a JSON-encoded STRING; build it inline with !Sub
-      # so the values track the template parameters.
+      # InputParameters is a JSON-encoded STRING built inline with !Sub.
       InputParameters: !Sub |
         {
-          "RequireUppercaseCharacters": "true",
-          "RequireLowercaseCharacters": "true",
-          "RequireSymbols": "true",
-          "RequireNumbers": "true",
+          "RequireUppercaseCharacters": "${PasswordPolicyRequireUppercase}",
+          "RequireLowercaseCharacters": "${PasswordPolicyRequireLowercase}",
+          "RequireSymbols": "${PasswordPolicyRequireSymbols}",
+          "RequireNumbers": "${PasswordPolicyRequireNumbers}",
           "MinimumPasswordLength": "${PasswordPolicyMinLength}",
           "PasswordReusePrevention": "${PasswordPolicyReusePrevention}",
           "MaxPasswordAge": "${PasswordPolicyMaxAge}"
         }
 
-  # Verifies Layer 3: every EBS volume is encrypted. Change-triggered on
-  # AWS::EC2::Volume. With EBS encryption-by-default enabled (Layer 3) and
-  # the CMK as the default key, new volumes will be encrypted automatically
-  # and this rule confirms it.
+  # Verifies Layer 3: attached EBS volumes are encrypted. Change-triggered.
   EncryptedVolumesRule:
     Type: AWS::Config::ConfigRule
-    DependsOn: ConfigDeliveryChannel
     Properties:
       ConfigRuleName: encrypted-volumes
       Description: Verifies attached EBS volumes are encrypted (CM-6 / SC-28, Layer 3).
@@ -305,14 +421,10 @@ Resources:
         ComplianceResourceTypes:
           - AWS::EC2::Volume
 
-  # Boundary-protection check: no security group permits unrestricted SSH
-  # (0.0.0.0/0 on port 22). Change-triggered on AWS::EC2::SecurityGroup.
-  # The Org SCP scp-restrict-network-changes-by-region prevents SG changes
-  # outside the approved regions; this rule reports any SG that already has
-  # the bad rule and would otherwise hide in a non-approved region.
+  # Boundary-protection: no security group allows unrestricted SSH
+  # (0.0.0.0/0 on port 22). Change-triggered.
   RestrictedSshRule:
     Type: AWS::Config::ConfigRule
-    DependsOn: ConfigDeliveryChannel
     Properties:
       ConfigRuleName: restricted-ssh
       Description: Verifies security groups do not allow unrestricted SSH (SC-7 / CM-6).
@@ -325,24 +437,28 @@ Resources:
 
 Outputs:
   ConfigBucketName:
+    Condition: ProvisionConfigService
     Description: S3 bucket holding Config delivery-channel snapshots and configuration history.
     Value: !Ref ConfigBucket
     Export:
       Name: !Sub "${AWS::StackName}-ConfigBucketName"
 
   ConfigBucketArn:
+    Condition: ProvisionConfigService
     Description: ARN of the Config delivery-channel bucket.
     Value: !GetAtt ConfigBucket.Arn
     Export:
       Name: !Sub "${AWS::StackName}-ConfigBucketArn"
 
   ConfigRecorderName:
+    Condition: ProvisionConfigService
     Description: Name of the configuration recorder.
     Value: !Ref ConfigRecorder
     Export:
       Name: !Sub "${AWS::StackName}-ConfigRecorderName"
 
   ConfigRecorderRoleArn:
+    Condition: ProvisionConfigService
     Description: ARN of the IAM role the configuration recorder assumes.
     Value: !GetAtt ConfigRecorderRole.Arn
     Export:

--- a/cloudformation/04-config.yaml
+++ b/cloudformation/04-config.yaml
@@ -1,0 +1,349 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  Layer 4 - Configuration & Compliance. Enables AWS Config (configuration
+  recorder + delivery channel + dedicated S3 bucket encrypted with the Layer 3
+  CMK) and deploys five managed Config Rules that continuously verify the
+  baselines established in Layers 1-3: multi-region CloudTrail, S3 default
+  encryption, the account password policy, encrypted EBS volumes, and the
+  SSH-port restriction. Where CloudTrail captures "who called the API,"
+  Config captures "what does every resource currently look like" - the state
+  half of the evidence story. Satisfies NIST 800-53 Rev 5 CM-2, CM-6, CM-8;
+  CJIS v6.0 5.10.4.1.
+
+Parameters:
+  ConfigCmkArn:
+    Type: String
+    AllowedPattern: "arn:aws[a-z-]*:kms:[a-z0-9-]+:[0-9]{12}:key/.+"
+    ConstraintDescription: Must be a full KMS key ARN, e.g. arn:aws:kms:<region>:<account>:key/<uuid>.
+    Description: >-
+      ARN of the Layer 3 compliance CMK (03-encryption.yaml output
+      ComplianceCmkArn). Encrypts the Config delivery-channel S3 bucket with
+      the agency-managed key (SC-28 / CJIS 5.10.1.2). Required - this layer
+      runs after Layer 3, so there is no SSE-S3 fallback.
+
+  ConfigSnapshotDeliveryFrequency:
+    Type: String
+    Default: Twelve_Hours
+    AllowedValues:
+      - One_Hour
+      - Three_Hours
+      - Six_Hours
+      - Twelve_Hours
+      - TwentyFour_Hours
+    Description: >-
+      Cadence at which Config delivers a full configuration snapshot to the
+      S3 bucket. Change events are recorded continuously regardless; this
+      controls only the periodic snapshot. Twelve_Hours is the conservative
+      balance between evidence currency and S3 / KMS API cost.
+
+  PasswordPolicyMinLength:
+    Type: Number
+    Default: 14
+    MinValue: 8
+    MaxValue: 128
+    Description: >-
+      Minimum password length the iam-password-policy Config rule asserts.
+      Should match the Layer 2 PasswordPolicy custom-resource value (default
+      14) so the rule checks the same baseline the policy enforces.
+
+  PasswordPolicyMaxAge:
+    Type: Number
+    Default: 90
+    MinValue: 1
+    MaxValue: 1095
+    Description: >-
+      Maximum password age (days) the iam-password-policy Config rule asserts.
+      Match Layer 2 (default 90).
+
+  PasswordPolicyReusePrevention:
+    Type: Number
+    Default: 24
+    MinValue: 1
+    MaxValue: 24
+    Description: >-
+      Password reuse-prevention count the iam-password-policy Config rule
+      asserts. Match Layer 2 (default 24).
+
+Resources:
+
+  # S3 bucket holding Config snapshots, configuration history, and delivery
+  # records. Same hardening philosophy as the Layer 1 CloudTrail bucket:
+  # public access blocked, versioned (a poisoned overwrite is recoverable),
+  # SSE-KMS with the agency-managed CMK, DeletionPolicy Retain to outlive a
+  # stack teardown - the configuration history is the CM-8 inventory record.
+  ConfigBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub "aws-config-${AWS::AccountId}"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: aws:kms
+              KMSMasterKeyID: !Ref ConfigCmkArn
+            # S3 Bucket Keys: one bucket-level key for envelope encryption
+            # cuts KMS API calls per object - the same cost win Layer 1's
+            # CloudTrail bucket takes after the second-pass deploy.
+            BucketKeyEnabled: true
+      VersioningConfiguration:
+        Status: Enabled
+
+  # Bucket policy: lets the Config service write delivery objects under the
+  # AWSLogs/<account>/Config/ prefix, denies deletion of those objects, and
+  # denies any unencrypted access. The aws:SourceAccount condition is the
+  # confused-deputy guard for the service-principal grants - matches the
+  # pattern Layer 1 uses for CloudTrail.
+  ConfigBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref ConfigBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowConfigGetBucketAcl
+            Effect: Allow
+            Principal:
+              Service: config.amazonaws.com
+            Action: s3:GetBucketAcl
+            Resource: !GetAtt ConfigBucket.Arn
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+          - Sid: AllowConfigListBucket
+            Effect: Allow
+            Principal:
+              Service: config.amazonaws.com
+            Action: s3:ListBucket
+            Resource: !GetAtt ConfigBucket.Arn
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+          - Sid: AllowConfigPutObject
+            Effect: Allow
+            Principal:
+              Service: config.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub "${ConfigBucket.Arn}/AWSLogs/${AWS::AccountId}/Config/*"
+            Condition:
+              StringEquals:
+                s3:x-amz-acl: bucket-owner-full-control
+                aws:SourceAccount: !Ref AWS::AccountId
+          - Sid: DenyDeliveryObjectDeletion
+            Effect: Deny
+            Principal: "*"
+            Action:
+              - s3:DeleteObject
+              - s3:DeleteObjectVersion
+            Resource: !Sub "${ConfigBucket.Arn}/AWSLogs/${AWS::AccountId}/Config/*"
+          - Sid: DenyInsecureTransport
+            Effect: Deny
+            Principal: "*"
+            Action: s3:*
+            Resource:
+              - !GetAtt ConfigBucket.Arn
+              - !Sub "${ConfigBucket.Arn}/*"
+            Condition:
+              Bool:
+                aws:SecureTransport: "false"
+
+  # IAM role the Config recorder assumes. The AWS-managed AWS_ConfigRole
+  # supplies Describe* / List* across services so Config can read every
+  # resource's state; the inline policy adds the write path (S3 PutObject
+  # under the delivery prefix) and KMS access on the Layer 3 CMK so the
+  # SSE-KMS PUT succeeds. The CMK's key policy delegates to IAM via its
+  # Statement 1 (account root, kms:*), so this IAM grant is what actually
+  # opens the door - no change to Layer 3's key policy is required.
+  ConfigRecorderRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: config.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWS_ConfigRole
+      Policies:
+        - PolicyName: ConfigDeliveryAndEncryption
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: WriteDeliveryObjects
+                Effect: Allow
+                Action: s3:PutObject
+                Resource: !Sub "${ConfigBucket.Arn}/AWSLogs/${AWS::AccountId}/Config/*"
+                Condition:
+                  StringEquals:
+                    s3:x-amz-acl: bucket-owner-full-control
+              - Sid: ReadBucketMetadata
+                Effect: Allow
+                Action:
+                  - s3:GetBucketAcl
+                  - s3:ListBucket
+                Resource: !GetAtt ConfigBucket.Arn
+              - Sid: EncryptDeliveryObjectsWithCmk
+                Effect: Allow
+                Action:
+                  - kms:GenerateDataKey
+                  - kms:Decrypt
+                  - kms:DescribeKey
+                Resource: !Ref ConfigCmkArn
+
+  # The configuration recorder. RecordingGroup.AllSupported with
+  # IncludeGlobalResourceTypes true is the CM-8 ("system component
+  # inventory") engine: every supported resource type, including global
+  # ones (IAM, CloudFront, Route 53), becomes a configuration item on
+  # every change. One recorder per region per account is the AWS limit.
+  ConfigRecorder:
+    Type: AWS::Config::ConfigurationRecorder
+    Properties:
+      Name: default
+      RoleARN: !GetAtt ConfigRecorderRole.Arn
+      RecordingGroup:
+        AllSupported: true
+        IncludeGlobalResourceTypes: true
+
+  # The delivery channel sends snapshots to the bucket on the configured
+  # cadence. KEY ORDERING DETAIL: Config does not actually START recording
+  # until a delivery channel exists - so the recorder + channel are two
+  # CFN resources but conceptually one running system. DependsOn is needed
+  # because neither references the other directly and CFN cannot otherwise
+  # infer the ordering.
+  ConfigDeliveryChannel:
+    Type: AWS::Config::DeliveryChannel
+    DependsOn: ConfigRecorder
+    Properties:
+      Name: default
+      S3BucketName: !Ref ConfigBucket
+      ConfigSnapshotDeliveryProperties:
+        DeliveryFrequency: !Ref ConfigSnapshotDeliveryFrequency
+
+  # ---------------------------------------------------------------------
+  # Config Rules - each verifies a specific Layer 1-3 baseline.
+  # Each is a managed AWS rule referenced by Source.SourceIdentifier;
+  # change-triggered rules need the recorder to be capturing the relevant
+  # resource type (covered by AllSupported above) and set Scope.
+  # ---------------------------------------------------------------------
+
+  # Verifies Layer 1: at least one multi-region trail is enabled and is
+  # logging. Periodic rule (no resource scope - the check is account-level).
+  MultiRegionCloudTrailRule:
+    Type: AWS::Config::ConfigRule
+    DependsOn: ConfigDeliveryChannel
+    Properties:
+      ConfigRuleName: multi-region-cloudtrail-enabled
+      Description: Verifies at least one multi-region CloudTrail is enabled (CM-6, Layer 1).
+      Source:
+        Owner: AWS
+        SourceIdentifier: MULTI_REGION_CLOUD_TRAIL_ENABLED
+
+  # Verifies Layers 1 and 3: every S3 bucket has default encryption enabled.
+  # Change-triggered on AWS::S3::Bucket. Before Layer 3's second pass the
+  # CloudTrail bucket reports COMPLIANT under SSE-S3; after the second pass
+  # it reports COMPLIANT under SSE-KMS with the CMK.
+  S3EncryptionEnabledRule:
+    Type: AWS::Config::ConfigRule
+    DependsOn: ConfigDeliveryChannel
+    Properties:
+      ConfigRuleName: s3-bucket-server-side-encryption-enabled
+      Description: Verifies S3 buckets have default encryption enabled (CM-6, Layer 1 / 3).
+      Source:
+        Owner: AWS
+        SourceIdentifier: S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::S3::Bucket
+
+  # Verifies Layer 2: the account password policy meets the baseline.
+  # InputParameters mirror Layer 2's PasswordPolicy custom resource so the
+  # rule checks exactly what was enforced - the values must stay in sync.
+  # Periodic rule (no resource scope - the policy is account-level).
+  IamPasswordPolicyRule:
+    Type: AWS::Config::ConfigRule
+    DependsOn: ConfigDeliveryChannel
+    Properties:
+      ConfigRuleName: iam-password-policy
+      Description: Verifies the account password policy matches the Layer 2 baseline (CM-6 / IA-5).
+      Source:
+        Owner: AWS
+        SourceIdentifier: IAM_PASSWORD_POLICY
+      # InputParameters is a JSON-encoded STRING; build it inline with !Sub
+      # so the values track the template parameters.
+      InputParameters: !Sub |
+        {
+          "RequireUppercaseCharacters": "true",
+          "RequireLowercaseCharacters": "true",
+          "RequireSymbols": "true",
+          "RequireNumbers": "true",
+          "MinimumPasswordLength": "${PasswordPolicyMinLength}",
+          "PasswordReusePrevention": "${PasswordPolicyReusePrevention}",
+          "MaxPasswordAge": "${PasswordPolicyMaxAge}"
+        }
+
+  # Verifies Layer 3: every EBS volume is encrypted. Change-triggered on
+  # AWS::EC2::Volume. With EBS encryption-by-default enabled (Layer 3) and
+  # the CMK as the default key, new volumes will be encrypted automatically
+  # and this rule confirms it.
+  EncryptedVolumesRule:
+    Type: AWS::Config::ConfigRule
+    DependsOn: ConfigDeliveryChannel
+    Properties:
+      ConfigRuleName: encrypted-volumes
+      Description: Verifies attached EBS volumes are encrypted (CM-6 / SC-28, Layer 3).
+      Source:
+        Owner: AWS
+        SourceIdentifier: ENCRYPTED_VOLUMES
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::EC2::Volume
+
+  # Boundary-protection check: no security group permits unrestricted SSH
+  # (0.0.0.0/0 on port 22). Change-triggered on AWS::EC2::SecurityGroup.
+  # The Org SCP scp-restrict-network-changes-by-region prevents SG changes
+  # outside the approved regions; this rule reports any SG that already has
+  # the bad rule and would otherwise hide in a non-approved region.
+  RestrictedSshRule:
+    Type: AWS::Config::ConfigRule
+    DependsOn: ConfigDeliveryChannel
+    Properties:
+      ConfigRuleName: restricted-ssh
+      Description: Verifies security groups do not allow unrestricted SSH (SC-7 / CM-6).
+      Source:
+        Owner: AWS
+        SourceIdentifier: INCOMING_SSH_DISABLED
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::EC2::SecurityGroup
+
+Outputs:
+  ConfigBucketName:
+    Description: S3 bucket holding Config delivery-channel snapshots and configuration history.
+    Value: !Ref ConfigBucket
+    Export:
+      Name: !Sub "${AWS::StackName}-ConfigBucketName"
+
+  ConfigBucketArn:
+    Description: ARN of the Config delivery-channel bucket.
+    Value: !GetAtt ConfigBucket.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-ConfigBucketArn"
+
+  ConfigRecorderName:
+    Description: Name of the configuration recorder.
+    Value: !Ref ConfigRecorder
+    Export:
+      Name: !Sub "${AWS::StackName}-ConfigRecorderName"
+
+  ConfigRecorderRoleArn:
+    Description: ARN of the IAM role the configuration recorder assumes.
+    Value: !GetAtt ConfigRecorderRole.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-ConfigRecorderRoleArn"


### PR DESCRIPTION
## Summary
- AWS Config (`cloudformation/04-config.yaml`) — conditional `ConfigurationRecorder` + `DeliveryChannel` + role + dedicated bucket gated by a `ManageConfigService` parameter (`Provision` default, `UseExisting` when the account already has Config enabled in this region — see Design notes)
- Config bucket: SSE-KMS with the Layer 3 CMK, **Object Lock COMPLIANCE mode** for parity with Layer 1's CloudTrail bucket (Config history is the CM-8 inventory evidence record), region-suffixed name (`aws-config-${AWS::Region}-${AWS::AccountId}`) for multi-region safety
- Recorder role: AWS-managed `AWS_ConfigRole` + inline policy for delivery-bucket writes and KMS access on the CMK; trust policy adds `aws:SourceAccount` confused-deputy guard
- **Six** managed Config Rules, one per Layer 1–3 deliverable plus a strict CJIS check:
  - `multi-region-cloudtrail-enabled` (Layer 1, `MaximumExecutionFrequency: One_Hour`)
  - `s3-bucket-server-side-encryption-enabled` (Layer 1/3 lax check)
  - `s3-default-encryption-kms` — **new** strict CJIS check; fails on AWS-managed AES256
  - `iam-password-policy` with `InputParameters` tracking Layer 2 via shared template parameters (no silent drift)
  - `encrypted-volumes` (Layer 3)
  - `restricted-ssh` (boundary protection)
- README refreshed: Layer 4 `ManageConfigService` note, same-region CMK warning, six-rule references, "all four layers" off-by-one fixed, "What This Project Demonstrates" no longer cites Config rules as future work

## Controls Addressed
- CM-2: Baseline Configuration — the CFN templates ARE the baseline; Config records current state for comparison
- CM-6: Configuration Settings — the six Config Rules enforce specific settings the baseline mandates
- CM-8: System Component Inventory — `RecordingGroup.AllSupported` is the auto-discovered inventory; Object Lock COMPLIANCE makes the history immutable evidence
- CJIS v6.0 5.10.4.1: Configuration management (maps to CM-2 / CM-6)

> **Design note — `ManageConfigService`:** AWS Config allows exactly one `ConfigurationRecorder` + one `DeliveryChannel` per region per account. If the account already has Config enabled (Control Tower, console-onboarding, prior stack), the `Provision` path raises `MaxNumberOfConfigurationRecordersExceededException`. Pass `ManageConfigService=UseExisting` instead — the stack creates only the six rules, which evaluate against the existing recorder.

> **Design note — recorder + channel ordering:** Config does not start recording until a delivery channel exists, AND the channel validates write access to the bucket on creation. `DependsOn: [ConfigRecorder, ConfigBucketPolicy]` on the channel ensures both prerequisites are in place — the implicit `!Ref`-on-bucket dependency alone does not guarantee the policy is attached yet.

> **Design note — strict vs. lax S3 encryption rules:** `s3-bucket-server-side-encryption-enabled` passes on SSE-S3, which uses AWS-managed keys and does not satisfy CJIS 5.10.1.2. The added `s3-default-encryption-kms` rule is the strict check; pre-Layer-3-second-pass CloudTrail buckets and the legacy `secure-bucket.yaml` will report NON_COMPLIANT against it — the intended signal that those buckets need to adopt the agency CMK.

## Test Plan
- [x] `cfn-lint` clean on `04-config.yaml` and all prior layer templates (no W-level warnings)
- [x] `aws cloudformation validate-template` passes; all 11 parameters wired in
- [x] Self-review: max-effort multi-pass review (5 angles × 8 candidates → 15 distinct findings consolidated → all 15 applied)
- [ ] Deploy Layer 4 → `aws configservice describe-configuration-recorder-status` shows `recording: true` — static-verified (`DependsOn` chain + DeliveryChannel triggers recording start); live-deploy deferred
- [ ] `aws configservice describe-compliance-by-config-rule` shows all six rules — static-verified (each rule's `SourceIdentifier` is an AWS-published managed-rule ID); live-deploy deferred
- [ ] Periodic rules evaluate at One_Hour cadence (not the 24-hour default) — static-verified (`MaximumExecutionFrequency: One_Hour` on both periodic rules); live-deploy deferred
- [ ] `iam-password-policy` rule's `InputParameters` track Layer 2 via shared CFN parameters — static-verified (all seven password-policy parameters mirror Layer 2's `PasswordPolicyLambda` defaults); live-deploy deferred

> **Validation note:** offline validation complete. Live deploy deferred per the management-account-only constraint — and the `ManageConfigService` parameter is the defensive escape hatch for accounts where Config is already enabled.

Closes #5
Closes 0XBN-57
