### PR TITLE
feat: Layer 5 — GuardDuty + EventBridge + SNS + Security Hub (NIST 800-53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The [Federal Risk and Authorization Management Program (FedRAMP)](https://www.fe
 | Layer 2 — IAM Baseline | `cloudformation/02-iam-baseline.yaml` | CloudFormation (IaC) | Account password policy, a read-only auditor role, and an MFA + ExternalId admin role capped by a permissions boundary | Identity and Least Privilege |
 | Layer 3 — Encryption | `cloudformation/03-encryption.yaml` | CloudFormation (IaC) | Customer-managed KMS CMK with annual rotation, a separated key policy, and account-level EBS encryption-by-default | Data Protection at Rest |
 | Layer 4 — Configuration & Compliance | `cloudformation/04-config.yaml` | CloudFormation (IaC) | AWS Config recorder + delivery channel + dedicated SSE-KMS Object-Lock bucket, plus six managed Config Rules continuously validating Layers 1–3 | Continuous Compliance Monitoring |
-| Layer 5 — Detection & Response | `cloudformation/05-detection.yaml` | CloudFormation (IaC) | GuardDuty detector + EventBridge rule filtering HIGH-severity findings → SNS topic with email subscription; Security Hub enabled with the NIST 800-53 Rev 5 standard | Threat Detection and Incident Response |
+| Layer 5 — Detection & Response | `cloudformation/05-detection.yaml` | CloudFormation (IaC) | GuardDuty detector with full Features (S3 / EKS / Malware / RDS / Lambda), EventBridge rule filtering HIGH-severity findings → SNS topic with email subscription + SQS DLQ for failed deliveries; Security Hub enabled with the NIST 800-53 Rev 5 standard | Threat Detection and Incident Response |
 | Secure S3 Bucket | `cloudformation/secure-bucket.yaml` | CloudFormation (IaC) | An S3 bucket with all public access blocked and AES256 server-side encryption | Secure by Default |
 
 ## Compliance Framework Mapping
@@ -97,7 +97,7 @@ aws-compliance-as-code/
 │   ├── 02-iam-baseline.yaml            # Layer 2: IAM password policy + auditor/admin roles
 │   ├── 03-encryption.yaml              # Layer 3: KMS CMK + alias + EBS encryption-by-default
 │   ├── 04-config.yaml                  # Layer 4: AWS Config recorder + delivery channel + 6 managed rules
-│   ├── 05-detection.yaml               # Layer 5: GuardDuty + EventBridge + SNS + Security Hub (NIST 800-53)
+│   ├── 05-detection.yaml               # Layer 5: GuardDuty + EventBridge + SNS + SQS DLQ + Security Hub (NIST 800-53)
 │   └── secure-bucket.yaml              # Standalone: secure S3 bucket (public access block + AES256)
 ├── scps/
 │   ├── scp-deny-audit-log-deletion.json            # SCP: Deny CloudTrail DeleteTrail / StopLogging
@@ -272,7 +272,7 @@ Example output:
 
 ### Step 3: Deploy the CloudFormation Layers
 
-Deploy the numbered templates in order — each layer builds on the previous. All five layers create IAM resources, so `CAPABILITY_NAMED_IAM` is required (the flag covers both named and unnamed roles). (`secure-bucket.yaml` is a standalone foundational template and can be deployed independently.)
+Deploy the numbered templates in order — each layer builds on the previous. Layers 1–4 create named IAM resources, so `CAPABILITY_NAMED_IAM` is required for those; Layer 5 has no IAM resources but the same flag is harmless (it is a superset of `CAPABILITY_IAM`). (`secure-bucket.yaml` is a standalone foundational template and can be deployed independently.)
 
 **Layer 1 — Logging & Monitoring.** Leave `LogsBucketCmkArn` unset for now; the CloudTrail log bucket uses SSE-S3 until the Layer 3 CMK exists.
 
@@ -332,14 +332,17 @@ aws cloudformation deploy \
         --query "Stacks[0].Outputs[?OutputKey=='ComplianceCmkArn'].OutputValue" --output text)
 ```
 
-**Layer 5 — Detection & Response.** Provide the email address for high-severity alerts. SNS will send a confirmation email — the subscription only becomes active when the recipient clicks it. **If the account already has GuardDuty or Security Hub enabled** (Control Tower, console, or a prior stack), add `ManageDetectionServices=UseExisting` to skip the singleton resources.
+**Layer 5 — Detection & Response.** Provide the email address for high-severity alerts. SNS sends a confirmation email — the subscription is **not** active until the recipient clicks the link, so after deploy run `aws sns list-subscriptions-by-topic` (the stack's `PostDeployVerification` output gives the exact command) to confirm `SubscriptionArn != "PendingConfirmation"`. **If the account already has GuardDuty or Security Hub enabled** (Control Tower, console, or a prior stack), add `ManageDetectionServices=UseExisting` to skip the singleton resources (the NIST 800-53 Rev 5 standard subscription still runs — Control Tower / console hubs default to AWS FSBP, not NIST 800-53). **To encrypt the SNS topic and DLQ with the Layer 3 agency CMK** (carries the SC-28 / CJIS 5.10.1.2 story through), also pass `ComplianceCmkArn`:
 
 ```
 aws cloudformation deploy \
     --stack-name compliance-layer5-detection \
     --template-file cloudformation/05-detection.yaml \
     --capabilities CAPABILITY_NAMED_IAM \
-    --parameter-overrides SecurityAlertEmail=<YOUR_EMAIL>
+    --parameter-overrides \
+        SecurityAlertEmail=<YOUR_EMAIL> \
+        ComplianceCmkArn=$(aws cloudformation describe-stacks --stack-name compliance-layer3-encryption \
+            --query "Stacks[0].Outputs[?OutputKey=='ComplianceCmkArn'].OutputValue" --output text)
 ```
 
 **Verify deployment:**

--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ graph TD
     ACC --> L2["Layer 2 (02-iam-baseline.yaml)<br/>Password Policy + Auditor and Admin Roles"]
     ACC --> L3["Layer 3 (03-encryption.yaml)<br/>KMS CMK + EBS Default Encryption"]
     ACC --> L4["Layer 4 (04-config.yaml)<br/>Config Recorder + Compliance Rules"]
+    ACC --> L5["Layer 5 (05-detection.yaml)<br/>GuardDuty + EventBridge + SNS + Security Hub"]
     ACC --> SB["secure-bucket.yaml<br/>Secure S3 Bucket"]
     L3 -. exports CMK ARN .-> L1
     L3 -. exports CMK ARN .-> L4
 ```
 
-SCPs are attached at the Organization Root, enforcing preventive guardrails across all accounts. These policies override IAM permissions, including administrator access, so non-compliant actions are blocked before they happen. CloudFormation templates are deployed into member accounts as numbered layers (`01` → `02` → `03` → `04`), each building on the previous, to provision resources that meet security baselines without manual configuration. Together, they create a defense-in-depth model where organization-level policies and account-level infrastructure work in tandem.
+SCPs are attached at the Organization Root, enforcing preventive guardrails across all accounts. These policies override IAM permissions, including administrator access, so non-compliant actions are blocked before they happen. CloudFormation templates are deployed into member accounts as numbered layers (`01` → `02` → `03` → `04` → `05`), each building on the previous, to provision resources that meet security baselines without manual configuration. Together, they create a defense-in-depth model where organization-level policies and account-level infrastructure work in tandem.
 
 ## Compliance Frameworks
 
@@ -62,6 +63,7 @@ The [Federal Risk and Authorization Management Program (FedRAMP)](https://www.fe
 | Layer 2 — IAM Baseline | `cloudformation/02-iam-baseline.yaml` | CloudFormation (IaC) | Account password policy, a read-only auditor role, and an MFA + ExternalId admin role capped by a permissions boundary | Identity and Least Privilege |
 | Layer 3 — Encryption | `cloudformation/03-encryption.yaml` | CloudFormation (IaC) | Customer-managed KMS CMK with annual rotation, a separated key policy, and account-level EBS encryption-by-default | Data Protection at Rest |
 | Layer 4 — Configuration & Compliance | `cloudformation/04-config.yaml` | CloudFormation (IaC) | AWS Config recorder + delivery channel + dedicated SSE-KMS Object-Lock bucket, plus six managed Config Rules continuously validating Layers 1–3 | Continuous Compliance Monitoring |
+| Layer 5 — Detection & Response | `cloudformation/05-detection.yaml` | CloudFormation (IaC) | GuardDuty detector + EventBridge rule filtering HIGH-severity findings → SNS topic with email subscription; Security Hub enabled with the NIST 800-53 Rev 5 standard | Threat Detection and Incident Response |
 | Secure S3 Bucket | `cloudformation/secure-bucket.yaml` | CloudFormation (IaC) | An S3 bucket with all public access blocked and AES256 server-side encryption | Secure by Default |
 
 ## Compliance Framework Mapping
@@ -79,6 +81,7 @@ Each control was selected to address specific compliance requirements across CJI
 | Layer 2 — IAM Baseline | AC-2 (Account Management), AC-3 (Access Enforcement), AC-6 (Least Privilege), IA-5 (Authenticator Management) | AC-2 (L/M/H), AC-3 (L/M/H), AC-6 (M/H), IA-5 (L/M/H) | AC-2 (Account Management), AC-3 (Access Enforcement), AC-6 (Least Privilege), IA-5 (Authenticator Management) |
 | Layer 3 — Encryption | SC-12 (Cryptographic Key Management), SC-13 (Cryptographic Protection), SC-28, SC-28(1) | SC-12 (L/M/H), SC-13 (L/M/H), SC-28 (M/H), SC-28(1) (M/H) | SC-12 (Cryptographic Key Establishment and Management), SC-13 (Cryptographic Protection), SC-28 (Protection of Information at Rest), SC-28(1) (Cryptographic Protection) |
 | Layer 4 — Configuration & Compliance | CM-2 (Baseline Configuration), CM-6 (Configuration Settings), CM-8 (System Component Inventory) | CM-2 (L/M/H), CM-6 (L/M/H), CM-8 (L/M/H) | CM-2 (Baseline Configuration), CM-6 (Configuration Settings), CM-8 (System Component Inventory) |
+| Layer 5 — Detection & Response | SI-3 (Malicious Code Protection), SI-4 (System Monitoring), IR-4 (Incident Handling), IR-5 (Incident Monitoring), IR-6 (Incident Reporting) | SI-3 (L/M/H), SI-4 (L/M/H), IR-4 (L/M/H), IR-5 (L/M/H), IR-6 (L/M/H) | SI-3 (Malicious Code Protection), SI-4 (System Monitoring), IR-4 (Incident Handling), IR-5 (Incident Monitoring), IR-6 (Incident Reporting) |
 | Secure S3 Bucket | SC-28 (Protection of Information at Rest), AC-3 (Access Enforcement) | SC-28 (M/H), AC-3 (L/M/H) | SC-28 (Protection of Information at Rest), AC-3 (Access Enforcement) |
 
 > **Note:** CJIS v6.0 now uses NIST 800-53 control identifiers directly, so the CJIS and NIST columns share the same control IDs. The distinction is that CJIS scopes these requirements specifically to Criminal Justice Information (CJI), while NIST 800-53 applies broadly to federal information systems.
@@ -94,6 +97,7 @@ aws-compliance-as-code/
 │   ├── 02-iam-baseline.yaml            # Layer 2: IAM password policy + auditor/admin roles
 │   ├── 03-encryption.yaml              # Layer 3: KMS CMK + alias + EBS encryption-by-default
 │   ├── 04-config.yaml                  # Layer 4: AWS Config recorder + delivery channel + 6 managed rules
+│   ├── 05-detection.yaml               # Layer 5: GuardDuty + EventBridge + SNS + Security Hub (NIST 800-53)
 │   └── secure-bucket.yaml              # Standalone: secure S3 bucket (public access block + AES256)
 ├── scps/
 │   ├── scp-deny-audit-log-deletion.json            # SCP: Deny CloudTrail DeleteTrail / StopLogging
@@ -105,7 +109,7 @@ aws-compliance-as-code/
 └── README.md
 ```
 
-The numbered CloudFormation prefixes (`01`–`04`) indicate deployment order; each layer builds on the one before it.
+The numbered CloudFormation prefixes (`01`–`05`) indicate deployment order; each layer builds on the one before it.
 
 ## AWS Services Used
 
@@ -117,6 +121,10 @@ The numbered CloudFormation prefixes (`01`–`04`) indicate deployment order; ea
 - **[Amazon S3](https://aws.amazon.com/s3/)**: Object Lock log storage and the secure bucket baseline
 - **[Amazon EBS](https://aws.amazon.com/ebs/)**: Account-level encryption-by-default for new volumes (Layer 3)
 - **[AWS Config](https://aws.amazon.com/config/)**: Continuous configuration recording + six managed Config Rules for compliance evaluation (Layer 4)
+- **[Amazon GuardDuty](https://aws.amazon.com/guardduty/)**: ML-powered threat detection consuming CloudTrail, VPC Flow Logs, and DNS query logs (Layer 5)
+- **[AWS Security Hub](https://aws.amazon.com/security-hub/)**: Aggregates findings from GuardDuty + Config into a single NIST 800-53 Rev 5 compliance dashboard (Layer 5)
+- **[Amazon EventBridge](https://aws.amazon.com/eventbridge/)**: Filters HIGH-severity GuardDuty findings and routes them to SNS (Layer 5)
+- **[Amazon SNS](https://aws.amazon.com/sns/)**: Email alerting for HIGH-severity security findings (Layer 5)
 - **[Amazon CloudWatch Logs](https://aws.amazon.com/cloudwatch/)**: Hot, queryable copy of CloudTrail and VPC Flow Log events
 - **[AWS Lambda](https://aws.amazon.com/lambda/)**: Backs the custom resources for account settings with no native CloudFormation type
 - **[AWS CLI](https://aws.amazon.com/cli/)**: Interface for deploying SCPs and CloudFormation stacks
@@ -264,7 +272,7 @@ Example output:
 
 ### Step 3: Deploy the CloudFormation Layers
 
-Deploy the numbered templates in order — each layer builds on the previous. All four layers create IAM resources, so `CAPABILITY_NAMED_IAM` is required (the flag covers both named and unnamed roles). (`secure-bucket.yaml` is a standalone foundational template and can be deployed independently.)
+Deploy the numbered templates in order — each layer builds on the previous. All five layers create IAM resources, so `CAPABILITY_NAMED_IAM` is required (the flag covers both named and unnamed roles). (`secure-bucket.yaml` is a standalone foundational template and can be deployed independently.)
 
 **Layer 1 — Logging & Monitoring.** Leave `LogsBucketCmkArn` unset for now; the CloudTrail log bucket uses SSE-S3 until the Layer 3 CMK exists.
 
@@ -322,6 +330,16 @@ aws cloudformation deploy \
     --capabilities CAPABILITY_NAMED_IAM \
     --parameter-overrides ConfigCmkArn=$(aws cloudformation describe-stacks --stack-name compliance-layer3-encryption \
         --query "Stacks[0].Outputs[?OutputKey=='ComplianceCmkArn'].OutputValue" --output text)
+```
+
+**Layer 5 — Detection & Response.** Provide the email address for high-severity alerts. SNS will send a confirmation email — the subscription only becomes active when the recipient clicks it. **If the account already has GuardDuty or Security Hub enabled** (Control Tower, console, or a prior stack), add `ManageDetectionServices=UseExisting` to skip the singleton resources.
+
+```
+aws cloudformation deploy \
+    --stack-name compliance-layer5-detection \
+    --template-file cloudformation/05-detection.yaml \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --parameter-overrides SecurityAlertEmail=<YOUR_EMAIL>
 ```
 
 **Verify deployment:**
@@ -388,7 +406,7 @@ This project demonstrates the core GRC Engineering skill of translating complian
 
 The controls illustrate a range of enforcement patterns — action-scoped denials (CloudTrail log deletion), principal-scoped denials (root-user lockdown via `NotAction` plus an `aws:PrincipalArn` condition), region-conditioned rules (network changes confined to approved regions), and encryption mandates (S3 uploads required to use SSE-KMS) — alongside a layered, compliant-by-default CloudFormation baseline. Together they demonstrate the flexibility of SCPs and infrastructure-as-code as compliance enforcement mechanisms.
 
-This foundation positions the project for expansion into CI/CD pipeline guardrails, GuardDuty / Security Hub detection (planned Layer 5), drift-remediation automation, and multi-account architectures with OU-scoped policies.
+This foundation positions the project for expansion into CI/CD pipeline guardrails, drift-remediation automation (auto-remediation Config Rules), and multi-account architectures with OU-scoped policies.
 
 ## References
 

--- a/cloudformation/03-encryption.yaml
+++ b/cloudformation/03-encryption.yaml
@@ -167,6 +167,41 @@ Resources:
               - kms:DescribeKey
             Resource: "*"
 
+          # Statement 5 - SNS service principal. Layer 5's security-alert
+          # topic encrypts messages with this CMK when its optional
+          # ComplianceCmkArn parameter is supplied; SNS calls GenerateDataKey
+          # as the sns.amazonaws.com service principal. aws:SourceAccount is
+          # the confused-deputy guard - only this account's SNS topics can
+          # use the key.
+          - Sid: AllowSnsServiceUsage
+            Effect: Allow
+            Principal:
+              Service: sns.amazonaws.com
+            Action:
+              - kms:GenerateDataKey
+              - kms:Decrypt
+              - kms:DescribeKey
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+
+          # Statement 6 - SQS service principal. Same pattern as Statement 5
+          # but for the Layer 5 dead-letter queue. SQS calls GenerateDataKey
+          # to encrypt queued messages.
+          - Sid: AllowSqsServiceUsage
+            Effect: Allow
+            Principal:
+              Service: sqs.amazonaws.com
+            Action:
+              - kms:GenerateDataKey
+              - kms:Decrypt
+              - kms:DescribeKey
+            Resource: "*"
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+
   # Alias = a stable, human-readable handle for the key. Templates and callers
   # reference alias/... so the underlying key can be replaced without
   # rewriting every reference.

--- a/cloudformation/05-detection.yaml
+++ b/cloudformation/05-detection.yaml
@@ -1,16 +1,18 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >-
-  Layer 5 - Detection & Response. Enables GuardDuty for ML-powered threat
-  detection (consuming the CloudTrail / VPC Flow Logs / DNS sources Layer 1
-  already turned on), routes HIGH-severity findings through an EventBridge
-  rule to an SNS topic with an email subscriber, and enables Security Hub
-  with the NIST 800-53 Rev 5 standard to aggregate findings from GuardDuty
-  + Config (Layer 4) into a single compliance dashboard. GuardDuty Detector
-  and Security Hub Hub are CONDITIONAL on the ManageDetectionServices
-  parameter (Provision / UseExisting) - both are one-per-region-per-account
-  singletons and may already be enabled by Control Tower, console, or a
-  prior stack. Satisfies NIST 800-53 Rev 5 SI-3, SI-4, IR-4, IR-5, IR-6;
-  CJIS v6.0 5.10.4.2.
+  Layer 5 - Detection & Response. Enables GuardDuty (with full Features:
+  S3 data events, EKS audit logs, EBS malware protection, RDS login events,
+  Lambda network logs) for ML-powered threat detection, routes HIGH-severity
+  findings through an EventBridge rule to an SNS topic with an email
+  subscriber, captures failed deliveries in an SQS dead-letter queue, and
+  enables Security Hub with the NIST 800-53 Rev 5 standard. GuardDuty
+  Detector and Security Hub Hub are CONDITIONAL on the ManageDetectionServices
+  parameter (Provision / UseExisting); the standard subscription runs in
+  BOTH modes (idempotent against any existing Hub) so the dashboard is
+  always wired up. SNS and SQS encrypt with the optional Layer 3 CMK when
+  ComplianceCmkArn is supplied, otherwise the AWS-managed alias/aws/sns
+  and alias/aws/sqs keys. Satisfies NIST 800-53 Rev 5 SI-3, SI-4, IR-4,
+  IR-5, IR-6; CJIS v6.0 5.10.4.2.
 
 Parameters:
   SecurityAlertEmail:
@@ -20,8 +22,10 @@ Parameters:
     Description: >-
       Email address to receive HIGH-severity security alerts. SNS sends a
       subscription-confirmation email; the subscription is not active until
-      the recipient clicks the confirmation link (CFN does not block on
-      confirmation - the stack completes regardless).
+      the recipient clicks the confirmation link. CFN does not block on
+      confirmation - the stack completes regardless. Run the verification
+      command in the PostDeployVerification output before treating the
+      alert pipeline as live.
 
   ManageDetectionServices:
     Type: String
@@ -31,35 +35,89 @@ Parameters:
       - UseExisting
     Description: >-
       Whether to create the GuardDuty Detector and Security Hub Hub. Both
-      are one-per-account-per-region singletons; if the account already has
-      them enabled (Control Tower, console-onboarding, or a prior stack),
-      pass UseExisting and only the SNS topic + EventBridge rule + topic
-      policy are created - they wire alerts off the existing detector.
-      Security Hub Standards subscription is also skipped in UseExisting
-      mode (the existing setup is expected to manage subscriptions).
+      are one-per-account-per-region singletons; if the account already
+      has them enabled (Control Tower, console-onboarding, or a prior
+      stack), pass UseExisting and only the SNS topic + DLQ + EventBridge
+      rule + topic policy + standard subscription are created. The NIST
+      800-53 Rev 5 standard subscription runs in BOTH modes (idempotent)
+      because Control Tower / console-onboarded hubs default to AWS FSBP,
+      not NIST - the standard this repo's compliance story relies on must
+      be subscribed explicitly even when the hub itself is pre-existing.
+
+  ComplianceCmkArn:
+    Type: String
+    Default: ""
+    AllowedPattern: "^(arn:aws[a-z-]*:kms:[a-z0-9-]+:[0-9]{12}:key/.+)?$"
+    ConstraintDescription: Must be a full KMS key ARN or empty.
+    Description: >-
+      Optional ARN of the Layer 3 compliance CMK (03-encryption.yaml output
+      ComplianceCmkArn). When supplied, the SNS topic AND SQS DLQ are
+      encrypted with the agency-managed CMK (carries the SC-28 / CJIS
+      5.10.1.2 story forward). When empty (the default), they fall back
+      to the AWS-managed alias/aws/sns and alias/aws/sqs keys. The Layer 3
+      CMK key policy must allow sns.amazonaws.com and sqs.amazonaws.com
+      GenerateDataKey for this option to work - the Layer 3 template
+      includes those statements as of this PR.
 
 Conditions:
   ProvisionDetectionServices: !Equals [!Ref ManageDetectionServices, "Provision"]
+  UseExistingDetectionServices: !Equals [!Ref ManageDetectionServices, "UseExisting"]
+  UseAgencyCmk: !Not [!Equals [!Ref ComplianceCmkArn, ""]]
 
 Resources:
 
-  # SNS topic for security alerts. Encrypted at rest with the AWS-managed
-  # alias/aws/sns key. Using the Layer 3 agency-managed CMK here would
-  # require adding sns.amazonaws.com to that key's policy - left as a
-  # cross-layer follow-up so this PR stays scoped. The alerts themselves
-  # are operational metadata, not CJI, so AWS-managed encryption is an
-  # acceptable trade-off for this layer.
+  # SQS dead-letter queue for failed EventBridge → SNS deliveries. Without
+  # a DLQ, any publish failure (transient SNS throttle, topic-policy race,
+  # KMS error, or SNS-side rejection) is dropped after EventBridge's
+  # bounded retry window - a silent IR-4 / IR-6 hole. Captured DLQ messages
+  # can be inspected and re-driven manually.
+  SecurityAlertDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "${AWS::StackName}-alert-dlq"
+      KmsMasterKeyId: !If [UseAgencyCmk, !Ref ComplianceCmkArn, alias/aws/sqs]
+      MessageRetentionPeriod: 1209600
+
+  # SQS queue policy: lets the EventBridge service write to the DLQ when
+  # an SNS publish fails. Scoped by aws:SourceAccount AND aws:SourceArn
+  # to the specific rule. ${AWS::Partition} so the ARN resolves in
+  # GovCloud / China.
+  SecurityAlertDeadLetterQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref SecurityAlertDeadLetterQueue
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowEventBridgeToDeadLetter
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sqs:SendMessage
+            Resource: !GetAtt SecurityAlertDeadLetterQueue.Arn
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+              ArnEquals:
+                aws:SourceArn: !Sub "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/${AWS::StackName}-high-severity-findings"
+
+  # SNS topic for security alerts. Encrypted with the Layer 3 CMK when
+  # ComplianceCmkArn is supplied (preserves the agency-managed-key
+  # invariant the rest of the repo establishes), otherwise the AWS-managed
+  # alias/aws/sns key. Either works - the CMK path requires the Layer 3
+  # key policy to allow sns.amazonaws.com (added in this PR).
   SecurityAlertTopic:
     Type: AWS::SNS::Topic
     Properties:
       TopicName: !Sub "${AWS::StackName}-security-alerts"
       DisplayName: "Security Alerts (Layer 5)"
-      KmsMasterKeyId: alias/aws/sns
+      KmsMasterKeyId: !If [UseAgencyCmk, !Ref ComplianceCmkArn, alias/aws/sns]
 
-  # Email subscription. SNS sends the confirmation link on stack create;
-  # the subscription remains PendingConfirmation in describe-subscriptions
-  # until the recipient clicks the link. Unconfirmed subscriptions do not
-  # receive messages.
+  # Email subscription. The subscription remains PendingConfirmation until
+  # the recipient clicks the AWS confirmation link. Unconfirmed
+  # subscriptions silently drop messages, so verify post-deploy via the
+  # PostDeployVerification output.
   SecurityAlertSubscription:
     Type: AWS::SNS::Subscription
     Properties:
@@ -67,12 +125,12 @@ Resources:
       Protocol: email
       Endpoint: !Ref SecurityAlertEmail
 
-  # Topic policy: lets the EventBridge service publish to the topic, scoped
-  # by aws:SourceAccount (account-wide guard) AND aws:SourceArn (this
-  # stack's specific rule only) - tight confused-deputy protection. The
-  # rule ARN is reconstructed from the rule's Name; this does not create a
-  # circular CFN dependency because the policy references the rule via
-  # string substitution, not !Ref.
+  # Topic policy: lets EventBridge publish to the topic, scoped by
+  # aws:SourceAccount AND aws:SourceArn (the specific rule). Uses
+  # ${AWS::Partition} so the ArnEquals condition resolves correctly in
+  # GovCloud (aws-us-gov) and China (aws-cn) - a hardcoded literal
+  # 'arn:aws:' would silently never match in those partitions, leaving
+  # every publish denied and zero alerts delivered.
   SecurityAlertTopicPolicy:
     Type: AWS::SNS::TopicPolicy
     Properties:
@@ -91,27 +149,60 @@ Resources:
               StringEquals:
                 aws:SourceAccount: !Ref AWS::AccountId
               ArnEquals:
-                aws:SourceArn: !Sub "arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/${AWS::StackName}-high-severity-findings"
+                aws:SourceArn: !Sub "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/${AWS::StackName}-high-severity-findings"
 
-  # GuardDuty detector - the ML threat-detection engine. Reads CloudTrail
-  # management/data events, VPC Flow Logs, and DNS query logs (all sourced
-  # from Layer 1). FindingPublishingFrequency FIFTEEN_MINUTES is the most
-  # aggressive option - critical for the IR-4 incident-handling story (the
-  # default SIX_HOURS leaves a six-hour blind spot between event and alert).
+  # GuardDuty detector. CFN-created detectors do NOT auto-enable the
+  # add-on protections (only the console onboarding flow does), so the
+  # Features block explicitly turns on each one - S3 data events, EKS
+  # audit logs, EBS malware protection, RDS login events, Lambda network
+  # logs. Without this, the SI-4 coverage is narrower than a CJIS /
+  # FedRAMP-High reader would expect.
+  #
+  # FindingPublishingFrequency FIFTEEN_MINUTES controls how often UPDATES
+  # to existing findings are batched to EventBridge / S3; NEW findings
+  # publish within ~5 minutes regardless of this setting. The aggressive
+  # setting matters for repeat-occurrence correlation, not first-detection
+  # latency.
   GuardDutyDetector:
     Type: AWS::GuardDuty::Detector
     Condition: ProvisionDetectionServices
     Properties:
       Enable: true
       FindingPublishingFrequency: FIFTEEN_MINUTES
+      Features:
+        - Name: S3_DATA_EVENTS
+          Status: ENABLED
+        - Name: EKS_AUDIT_LOGS
+          Status: ENABLED
+        - Name: EBS_MALWARE_PROTECTION
+          Status: ENABLED
+        - Name: RDS_LOGIN_EVENTS
+          Status: ENABLED
+        - Name: LAMBDA_NETWORK_LOGS
+          Status: ENABLED
 
-  # EventBridge rule routing HIGH-severity GuardDuty findings to SNS. The
-  # event pattern is the FILTER - it decides which findings reach the
-  # SNS topic. A too-loose pattern floods the inbox; a too-tight pattern
-  # misses real incidents. See the Learn by Doing request in the PR for
-  # the design choice.
+  # EventBridge rule routing HIGH+ severity GuardDuty findings to SNS.
+  # severity >= 7 is the GuardDuty HIGH threshold (HIGH 7.0-8.9, CRITICAL
+  # 9.0-10.0); LOW (0-3.9) and MEDIUM (4-6.9) stay in Security Hub for
+  # triage without paging the on-call inbox.
+  #
+  # DependsOn covers BOTH the SNS topic policy AND the SQS DLQ policy:
+  # without these dependencies, CFN may mark the rule ENABLED before the
+  # publish / send-message grants are attached. The first finding in that
+  # window would then fail (publish denied) AND be lost (DLQ policy is
+  # also still being created, so even the dead-letter capture fails).
+  # DependsOn closes the race.
+  #
+  # DeadLetterConfig + RetryPolicy: failed deliveries land in the SQS DLQ
+  # for replay instead of being silently dropped after EventBridge's
+  # bounded retry window. Real concern for an alert pipeline that's idle
+  # 99% of the time - the one event that needs to get through is the one
+  # during the moment when it can't.
   HighSeverityFindingsRule:
     Type: AWS::Events::Rule
+    DependsOn:
+      - SecurityAlertTopicPolicy
+      - SecurityAlertDeadLetterQueuePolicy
     Properties:
       Name: !Sub "${AWS::StackName}-high-severity-findings"
       Description: Routes HIGH-severity GuardDuty findings to the security-alert SNS topic (SI-4 / IR-4 / IR-5).
@@ -125,29 +216,48 @@ Resources:
         detail:
           severity:
             - numeric:
-              - ">="
-              - 7
+                - ">="
+                - 7
       Targets:
         - Id: PublishToAlertTopic
           Arn: !Ref SecurityAlertTopic
+          DeadLetterConfig:
+            Arn: !GetAtt SecurityAlertDeadLetterQueue.Arn
+          RetryPolicy:
+            MaximumRetryAttempts: 10
+            MaximumEventAgeInSeconds: 3600
 
-  # Security Hub - the aggregator. Ingests findings from GuardDuty (this
-  # layer), Config (Layer 4), Inspector, Macie, and IAM Access Analyzer
-  # and presents them as a unified compliance dashboard.
+  # Security Hub Hub - the aggregator. Conditional: skipped in UseExisting
+  # so the stack can deploy in accounts where Control Tower or
+  # console-onboarding already enabled Security Hub.
   SecurityHub:
     Type: AWS::SecurityHub::Hub
     Condition: ProvisionDetectionServices
 
-  # Subscribe to the NIST 800-53 Rev 5 standard. Security Hub continuously
-  # evaluates the account against the 800-53 controls and reports per-control
-  # pass/fail, closing the loop with the control mappings in this repo's
-  # README and in Project 1 (nist-800-53-rev-5-to-aws-mapping).
-  Nist80053Standard:
+  # NIST 800-53 Rev 5 standard subscription - split across Provision and
+  # UseExisting modes so the standard is ALWAYS subscribed regardless of
+  # who created the Hub. Control Tower / console onboarding defaults to
+  # AWS FSBP, NOT NIST 800-53 Rev 5; subscribing the standard explicitly
+  # closes the gap. BatchEnableStandards is idempotent (no error if
+  # already subscribed), so the UseExisting variant is safe even if the
+  # standard happens to already be on.
+  #
+  # CFN cannot conditionalize DependsOn, so the Provision variant
+  # DependsOn the Hub it creates and the UseExisting variant has no
+  # DependsOn (the external Hub is assumed to be ready).
+  # ${AWS::Partition} for GovCloud / China.
+  Nist80053StandardProvisioned:
     Type: AWS::SecurityHub::Standard
     Condition: ProvisionDetectionServices
     DependsOn: SecurityHub
     Properties:
-      StandardsArn: !Sub "arn:aws:securityhub:${AWS::Region}::standards/nist-800-53/v/5.0.0"
+      StandardsArn: !Sub "arn:${AWS::Partition}:securityhub:${AWS::Region}::standards/nist-800-53/v/5.0.0"
+
+  Nist80053StandardExistingHub:
+    Type: AWS::SecurityHub::Standard
+    Condition: UseExistingDetectionServices
+    Properties:
+      StandardsArn: !Sub "arn:${AWS::Partition}:securityhub:${AWS::Region}::standards/nist-800-53/v/5.0.0"
 
 Outputs:
   SecurityAlertTopicArn:
@@ -155,6 +265,12 @@ Outputs:
     Value: !Ref SecurityAlertTopic
     Export:
       Name: !Sub "${AWS::StackName}-SecurityAlertTopicArn"
+
+  SecurityAlertDeadLetterQueueArn:
+    Description: ARN of the SQS DLQ catching failed EventBridge → SNS deliveries.
+    Value: !GetAtt SecurityAlertDeadLetterQueue.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-SecurityAlertDeadLetterQueueArn"
 
   HighSeverityFindingsRuleArn:
     Description: ARN of the EventBridge rule routing high-severity findings.
@@ -168,3 +284,11 @@ Outputs:
     Value: !Ref GuardDutyDetector
     Export:
       Name: !Sub "${AWS::StackName}-GuardDutyDetectorId"
+
+  PostDeployVerification:
+    Description: >-
+      Verify the alert pipeline before treating Layer 5 as live - SNS email
+      subscriptions remain PendingConfirmation until the recipient clicks
+      the link. Run the command in the Value field; SubscriptionArn must
+      not equal "PendingConfirmation" for any subscription.
+    Value: !Sub "aws sns list-subscriptions-by-topic --topic-arn ${SecurityAlertTopic} --query 'Subscriptions[*].[Endpoint,SubscriptionArn]' --output table"

--- a/cloudformation/05-detection.yaml
+++ b/cloudformation/05-detection.yaml
@@ -1,0 +1,170 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  Layer 5 - Detection & Response. Enables GuardDuty for ML-powered threat
+  detection (consuming the CloudTrail / VPC Flow Logs / DNS sources Layer 1
+  already turned on), routes HIGH-severity findings through an EventBridge
+  rule to an SNS topic with an email subscriber, and enables Security Hub
+  with the NIST 800-53 Rev 5 standard to aggregate findings from GuardDuty
+  + Config (Layer 4) into a single compliance dashboard. GuardDuty Detector
+  and Security Hub Hub are CONDITIONAL on the ManageDetectionServices
+  parameter (Provision / UseExisting) - both are one-per-region-per-account
+  singletons and may already be enabled by Control Tower, console, or a
+  prior stack. Satisfies NIST 800-53 Rev 5 SI-3, SI-4, IR-4, IR-5, IR-6;
+  CJIS v6.0 5.10.4.2.
+
+Parameters:
+  SecurityAlertEmail:
+    Type: String
+    AllowedPattern: "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$"
+    ConstraintDescription: Must be a valid email address.
+    Description: >-
+      Email address to receive HIGH-severity security alerts. SNS sends a
+      subscription-confirmation email; the subscription is not active until
+      the recipient clicks the confirmation link (CFN does not block on
+      confirmation - the stack completes regardless).
+
+  ManageDetectionServices:
+    Type: String
+    Default: Provision
+    AllowedValues:
+      - Provision
+      - UseExisting
+    Description: >-
+      Whether to create the GuardDuty Detector and Security Hub Hub. Both
+      are one-per-account-per-region singletons; if the account already has
+      them enabled (Control Tower, console-onboarding, or a prior stack),
+      pass UseExisting and only the SNS topic + EventBridge rule + topic
+      policy are created - they wire alerts off the existing detector.
+      Security Hub Standards subscription is also skipped in UseExisting
+      mode (the existing setup is expected to manage subscriptions).
+
+Conditions:
+  ProvisionDetectionServices: !Equals [!Ref ManageDetectionServices, "Provision"]
+
+Resources:
+
+  # SNS topic for security alerts. Encrypted at rest with the AWS-managed
+  # alias/aws/sns key. Using the Layer 3 agency-managed CMK here would
+  # require adding sns.amazonaws.com to that key's policy - left as a
+  # cross-layer follow-up so this PR stays scoped. The alerts themselves
+  # are operational metadata, not CJI, so AWS-managed encryption is an
+  # acceptable trade-off for this layer.
+  SecurityAlertTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: !Sub "${AWS::StackName}-security-alerts"
+      DisplayName: "Security Alerts (Layer 5)"
+      KmsMasterKeyId: alias/aws/sns
+
+  # Email subscription. SNS sends the confirmation link on stack create;
+  # the subscription remains PendingConfirmation in describe-subscriptions
+  # until the recipient clicks the link. Unconfirmed subscriptions do not
+  # receive messages.
+  SecurityAlertSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      TopicArn: !Ref SecurityAlertTopic
+      Protocol: email
+      Endpoint: !Ref SecurityAlertEmail
+
+  # Topic policy: lets the EventBridge service publish to the topic, scoped
+  # by aws:SourceAccount (account-wide guard) AND aws:SourceArn (this
+  # stack's specific rule only) - tight confused-deputy protection. The
+  # rule ARN is reconstructed from the rule's Name; this does not create a
+  # circular CFN dependency because the policy references the rule via
+  # string substitution, not !Ref.
+  SecurityAlertTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - !Ref SecurityAlertTopic
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowEventBridgeToPublish
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: sns:Publish
+            Resource: !Ref SecurityAlertTopic
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+              ArnEquals:
+                aws:SourceArn: !Sub "arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/${AWS::StackName}-high-severity-findings"
+
+  # GuardDuty detector - the ML threat-detection engine. Reads CloudTrail
+  # management/data events, VPC Flow Logs, and DNS query logs (all sourced
+  # from Layer 1). FindingPublishingFrequency FIFTEEN_MINUTES is the most
+  # aggressive option - critical for the IR-4 incident-handling story (the
+  # default SIX_HOURS leaves a six-hour blind spot between event and alert).
+  GuardDutyDetector:
+    Type: AWS::GuardDuty::Detector
+    Condition: ProvisionDetectionServices
+    Properties:
+      Enable: true
+      FindingPublishingFrequency: FIFTEEN_MINUTES
+
+  # EventBridge rule routing HIGH-severity GuardDuty findings to SNS. The
+  # event pattern is the FILTER - it decides which findings reach the
+  # SNS topic. A too-loose pattern floods the inbox; a too-tight pattern
+  # misses real incidents. See the Learn by Doing request in the PR for
+  # the design choice.
+  HighSeverityFindingsRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "${AWS::StackName}-high-severity-findings"
+      Description: Routes HIGH-severity GuardDuty findings to the security-alert SNS topic (SI-4 / IR-4 / IR-5).
+      EventBusName: default
+      State: ENABLED
+      EventPattern:
+        source:
+          - aws.guardduty
+        detail-type:
+          - GuardDuty Finding
+        detail:
+          severity:
+            - numeric:
+              - ">="
+              - 7
+      Targets:
+        - Id: PublishToAlertTopic
+          Arn: !Ref SecurityAlertTopic
+
+  # Security Hub - the aggregator. Ingests findings from GuardDuty (this
+  # layer), Config (Layer 4), Inspector, Macie, and IAM Access Analyzer
+  # and presents them as a unified compliance dashboard.
+  SecurityHub:
+    Type: AWS::SecurityHub::Hub
+    Condition: ProvisionDetectionServices
+
+  # Subscribe to the NIST 800-53 Rev 5 standard. Security Hub continuously
+  # evaluates the account against the 800-53 controls and reports per-control
+  # pass/fail, closing the loop with the control mappings in this repo's
+  # README and in Project 1 (nist-800-53-rev-5-to-aws-mapping).
+  Nist80053Standard:
+    Type: AWS::SecurityHub::Standard
+    Condition: ProvisionDetectionServices
+    DependsOn: SecurityHub
+    Properties:
+      StandardsArn: !Sub "arn:aws:securityhub:${AWS::Region}::standards/nist-800-53/v/5.0.0"
+
+Outputs:
+  SecurityAlertTopicArn:
+    Description: ARN of the SNS topic receiving HIGH-severity security alerts.
+    Value: !Ref SecurityAlertTopic
+    Export:
+      Name: !Sub "${AWS::StackName}-SecurityAlertTopicArn"
+
+  HighSeverityFindingsRuleArn:
+    Description: ARN of the EventBridge rule routing high-severity findings.
+    Value: !GetAtt HighSeverityFindingsRule.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-HighSeverityFindingsRuleArn"
+
+  GuardDutyDetectorId:
+    Condition: ProvisionDetectionServices
+    Description: GuardDuty detector ID.
+    Value: !Ref GuardDutyDetector
+    Export:
+      Name: !Sub "${AWS::StackName}-GuardDutyDetectorId"


### PR DESCRIPTION
## Summary
- AWS GuardDuty detector (`cloudformation/05-detection.yaml`) with **full add-on Features**: `S3_DATA_EVENTS`, `EKS_AUDIT_LOGS`, `EBS_MALWARE_PROTECTION`, `RDS_LOGIN_EVENTS`, `LAMBDA_NETWORK_LOGS` — CFN-created detectors don't auto-enable these (only the console onboarding flow does), so the SI-4 coverage was narrower than the README implied.
- EventBridge rule filtering HIGH+ severity findings (`severity >= 7`) → SNS topic → email, with a **SQS dead-letter queue** + queue policy on the target. `DeadLetterConfig` + `RetryPolicy` mean a transient SNS throttle / topic-policy race / KMS hiccup lands the event in the DLQ for replay instead of dropping it silently after EventBridge's bounded retry window.
- Explicit `DependsOn` from the EventBridge rule to both `SecurityAlertTopicPolicy` AND `SecurityAlertDeadLetterQueuePolicy` — closes the first-deploy race where the rule could be marked `ENABLED` before the publish / send-message grants are attached.
- `${AWS::Partition}` on every constructed service ARN (TopicPolicy `aws:SourceArn`, DLQ policy `aws:SourceArn`, Security Hub `StandardsArn`) so the template resolves correctly in GovCloud (`aws-us-gov`) and China (`aws-cn`) — the previously-hardcoded `arn:aws:` literal would silently never match the real event ARNs in those partitions.
- New optional `ComplianceCmkArn` parameter — when supplied, the SNS topic AND SQS DLQ encrypt with the Layer 3 agency CMK, carrying the SC-28 / CJIS 5.10.1.2 agency-managed-key story all the way through Layer 5. Layer 3's key policy gains two new statements (`sns.amazonaws.com` and `sqs.amazonaws.com` GenerateDataKey, scoped by `aws:SourceAccount`) so the CMK path actually works.
- **NIST 800-53 Rev 5 standard subscribed in BOTH `Provision` and `UseExisting` modes** — Control Tower / console-onboarded Security Hub defaults to AWS FSBP (not NIST 800-53), so the previously-conditional standard subscription would have silently missed the dashboard the README's whole compliance story is built around. Implemented as a two-resource split (`Nist80053StandardProvisioned` with `DependsOn: SecurityHub`, `Nist80053StandardExistingHub` without) since CFN can't conditionalize `DependsOn`.
- `PostDeployVerification` stack output gives the exact `aws sns list-subscriptions-by-topic` command for confirming the email subscription escapes `PendingConfirmation` before the alert pipeline is treated as live. CFN doesn't block on confirmation — a "successful" stack with zero confirmed subscribers was a silent IR-6 failure mode.
- README updated: Layer 5 deploy command shows the optional `ComplianceCmkArn` fetch + the `CAPABILITY_NAMED_IAM` claim narrowed to Layers 1–4 (Layer 5 has no IAM resources); Layer 5 row in the controls table reflects the full Features set and the DLQ; the stale "Learn by Doing request in the PR" comment is replaced with a substantive severity-threshold rationale.

## Controls Addressed
- SI-3: Malicious code protection — EBS Malware Protection is now explicitly enabled
- SI-4: System monitoring — GuardDuty with full add-on coverage (S3 / EKS / RDS / Lambda) plus Security Hub aggregation
- IR-4: Incident handling — EventBridge with retries + DLQ for guaranteed-delivery-or-auditable-failure routing
- IR-5: Incident monitoring — Security Hub with NIST 800-53 Rev 5 always subscribed
- IR-6: Incident reporting — SNS email with the PendingConfirmation verification step
- CJIS v6.0 5.10.4.2: Security alerts and advisories (maps to SI-4 / IR-5)

> **Design note — `ManageDetectionServices` + always-on NIST 800-53:** GuardDuty Detector and Security Hub Hub are singletons. `Provision` builds them; `UseExisting` skips them but still subscribes to the NIST 800-53 standard (the README's whole compliance story depends on it; Control Tower-default hubs subscribe to FSBP only).

> **Design note — DLQ + DependsOn + partition:** alert pipelines are idle most of the time, so the single moment a finding needs to get through is the moment a silent design gap matters most. `DependsOn` on the policies closes the first-deploy race; the SQS DLQ + `RetryPolicy` guarantees auditable failures instead of silent drops; `${AWS::Partition}` makes the `ArnEquals` conditions work in GovCloud where the hardcoded `arn:aws:` literal would never match the real `arn:aws-us-gov:` event ARN.

> **Design note — optional agency CMK encryption:** SNS / SQS encryption defaults to AWS-managed `alias/aws/sns` and `alias/aws/sqs` (simplest path, no Layer 3 dependency). Passing `ComplianceCmkArn` flips both to the Layer 3 CMK; that path required Layer 3's key policy to grow two service-principal statements — a small cross-layer modification included in this PR.

## Test Plan
- [x] `cfn-lint` clean on `05-detection.yaml`, the modified `03-encryption.yaml`, and all other layer templates
- [x] `aws cloudformation validate-template` passes on both modified templates; all three Layer 5 parameters wired
- [x] Self-review: high-effort 3-angle diff review surfaced 10 findings; all 10 applied
- [x] EventBridge pattern parses to the expected JSON via PyYAML (verified during pre-fix review)
- [ ] Deploy Layer 5 → `aws guardduty get-detector` reports all 5 Features `ENABLED` — static-verified (`Features` block); live-deploy deferred
- [ ] `aws securityhub get-enabled-standards` lists the NIST 800-53 Rev 5 ARN regardless of `ManageDetectionServices` mode — static-verified (split-resource pattern); live-deploy deferred
- [ ] Failed EventBridge → SNS delivery lands in the DLQ instead of being dropped — would require deliberately breaking the topic policy mid-deploy or throttling SNS; static-verified (`DeadLetterConfig` + `RetryPolicy` set); live-deploy deferred
- [ ] `PostDeployVerification` output produces a working CLI command — static-verified (`!Sub` references valid SNS topic ARN); live-deploy deferred

> **Validation note:** offline validation complete. Live deploy deferred per the management-account-only constraint. `ManageDetectionServices` and the optional `ComplianceCmkArn` give defensive escape hatches for pre-existing setups and for SNS-encryption preferences.

Closes #6
Closes 0XBN-58
