### PR TITLE
feat: cross-stack refs for bucket ARN and role-name parameters for boundary Deny

### DIFF
--- a/cloudformation/01-logging.yaml
+++ b/cloudformation/01-logging.yaml
@@ -417,6 +417,12 @@ Outputs:
     Export:
       Name: !Sub "${AWS::StackName}-CloudTrailLogsBucketName"
 
+  CloudTrailLogsBucketArn:
+    Description: ARN of the CloudTrail logs bucket. Imported by Layer 2 to scope BucketPolicyAdminRole's bucket-config grants and to anchor BucketPolicyAdminBoundary's Allow set, replacing string-constructed bucket ARNs that silently drifted if the bucket-name template changed.
+    Value: !GetAtt CloudTrailLogsBucket.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-CloudTrailLogsBucketArn"
+
   CloudTrailArn:
     Description: ARN of the multi-region trail.
     Value: !GetAtt MainTrail.Arn

--- a/cloudformation/02-iam-baseline.yaml
+++ b/cloudformation/02-iam-baseline.yaml
@@ -71,6 +71,44 @@ Parameters:
       deploy with a long random string; the default is a placeholder so the
       template validates but should never ship to production.
 
+  Layer1StackName:
+    Type: String
+    Default: compliance-layer1-logging
+    Description: >-
+      Name of the deployed Layer 1 (01-logging.yaml) stack. Layer 2 imports
+      CloudTrailLogsBucketArn from that stack's Outputs to scope
+      BucketPolicyAdminRole's bucket-config grants and BucketPolicyAdminBoundary's
+      Allow set, replacing the string-constructed bucket ARN that silently
+      drifted if Layer 1's bucket-name template changed. Override if Layer 1
+      was deployed under a non-default stack name.
+
+  AdminRoleSuffix:
+    Type: String
+    Default: admin
+    Description: >-
+      Suffix appended to AWS::StackName to construct AdminRole's RoleName and
+      the matching Resource ARN inside DenyComplianceRoleTampering. Single
+      Parameter drives both consumers so renaming the role updates both sites
+      atomically; eliminates the silent-drift footgun where a rename made the
+      boundary's Deny stop matching the actual role.
+
+  AuditorRoleSuffix:
+    Type: String
+    Default: auditor
+    Description: >-
+      Suffix appended to AWS::StackName to construct AuditorRole's RoleName.
+      AuditorRole has no PermissionsBoundary, so DenyComplianceRoleTampering's
+      Resource entry for it uses !GetAtt AuditorRole.Arn instead of a
+      string-constructed ARN; the suffix here drives only the role name.
+
+  BucketPolicyAdminRoleSuffix:
+    Type: String
+    Default: bucket-policy-admin
+    Description: >-
+      Suffix appended to AWS::StackName to construct BucketPolicyAdminRole's
+      RoleName and the matching Resource ARN inside DenyComplianceRoleTampering.
+      Same rationale as AdminRoleSuffix.
+
 Resources:
 
   # IAM password policy is an account-wide singleton with no CloudFormation
@@ -234,9 +272,17 @@ Resources:
               - iam:PutRolePolicy
               - iam:PutRolePermissionsBoundary
             Resource:
-              - !Sub "arn:aws:iam::${AWS::AccountId}:role/${AWS::StackName}-admin"
-              - !Sub "arn:aws:iam::${AWS::AccountId}:role/${AWS::StackName}-auditor"
-              - !Sub "arn:aws:iam::${AWS::AccountId}:role/${AWS::StackName}-bucket-policy-admin"
+              # AdminRole and BucketPolicyAdminRole wear PermissionsBoundary
+              # references to this same stack's ManagedPolicies, so
+              # !GetAtt RoleName.Arn would create a CFN dependency cycle
+              # (boundary -> role; role -> boundary). String-construct via
+              # the same suffix Parameter that drives the role's RoleName
+              # so a rename updates both sites atomically.
+              - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${AWS::StackName}-${AdminRoleSuffix}"
+              # AuditorRole has no PermissionsBoundary -> cycle-free, can
+              # use a direct dependency edge.
+              - !GetAtt AuditorRole.Arn
+              - !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${AWS::StackName}-${BucketPolicyAdminRoleSuffix}"
           # Self-referential closure for AdminRole (wears this boundary,
           # holds iam:* via AdministratorAccess). Denies the four
           # ManagedPolicy mutation verbs against this boundary AND the
@@ -272,7 +318,7 @@ Resources:
   AuditorRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-auditor"
+      RoleName: !Sub "${AWS::StackName}-${AuditorRoleSuffix}"
       Description: >-
         Read-only role for compliance evidence collection. Requires MFA on
         assume.
@@ -312,7 +358,7 @@ Resources:
   AdminRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-admin"
+      RoleName: !Sub "${AWS::StackName}-${AdminRoleSuffix}"
       Description: >-
         Privileged break-glass role. Requires MFA + ExternalId on assume.
         Permissions capped by AdminPermissionsBoundary.
@@ -374,7 +420,8 @@ Resources:
               - s3:PutReplicationConfiguration
               - s3:PutBucketTagging
               - s3:PutBucketOwnershipControls
-            Resource: !Sub "arn:aws:s3:::cloudtrail-logs-${AWS::AccountId}"
+            Resource:
+              Fn::ImportValue: !Sub "${Layer1StackName}-CloudTrailLogsBucketArn"
           # Mirror of DenyBoundarySelfMutation in AdminPermissionsBoundary.
           # Anticipatory hardening: under current state this Statement is
           # unreachable because BucketPolicyAdminRole has no iam:* in its
@@ -408,7 +455,7 @@ Resources:
   BucketPolicyAdminRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${AWS::StackName}-bucket-policy-admin"
+      RoleName: !Sub "${AWS::StackName}-${BucketPolicyAdminRoleSuffix}"
       Description: >-
         Narrow break-glass role permitted to modify the CloudTrail bucket
         policy and related bucket-config actions. Pass its ARN to Layer
@@ -454,7 +501,8 @@ Resources:
                   - s3:PutReplicationConfiguration
                   - s3:PutBucketTagging
                   - s3:PutBucketOwnershipControls
-                Resource: !Sub "arn:aws:s3:::cloudtrail-logs-${AWS::AccountId}"
+                Resource:
+                  Fn::ImportValue: !Sub "${Layer1StackName}-CloudTrailLogsBucketArn"
       PermissionsBoundary: !Ref BucketPolicyAdminBoundary
       MaxSessionDuration: 3600
 


### PR DESCRIPTION
## Summary

- **Layer 1:** adds `CloudTrailLogsBucketArn` export to `cloudformation/01-logging.yaml` so Layer 2 can `Fn::ImportValue` the bucket ARN instead of constructing it as a string.
- **Layer 2:** adds four new Parameters to `cloudformation/02-iam-baseline.yaml` — `Layer1StackName`, `AdminRoleSuffix`, `AuditorRoleSuffix`, `BucketPolicyAdminRoleSuffix` — and threads them through `RoleName` properties + `DenyComplianceRoleTampering` Resource ARNs so renaming a role updates both sites atomically (closes the silent-drift footgun).
- **Layer 2:** replaces the two literal `arn:aws:s3:::cloudtrail-logs-${AWS::AccountId}` strings (in `BucketPolicyAdminBoundary.CapToCloudTrailBucketConfig` and `BucketPolicyAdminRole`'s inline `ManageCloudTrailBucketConfig`) with `Fn::ImportValue: !Sub "${Layer1StackName}-CloudTrailLogsBucketArn"`. Creates an explicit cross-stack dependency: Layer 1 cannot be deleted while Layer 2 imports its export.
- **AuditorRole** gets `!GetAtt AuditorRole.Arn` in the Deny Resource list (cycle-free because AuditorRole has no `PermissionsBoundary`); the bounded roles necessarily stay on string-constructed ARNs, with the cycle constraint documented inline.

## CFN constraint discovered + design choice

Issue #19 originally specified `!GetAtt RoleName.Arn` for all three roles in `DenyComplianceRoleTampering`. That works only for `AuditorRole`. For `AdminRole` and `BucketPolicyAdminRole`, `!GetAtt` would create a circular dependency:

- `AdminRole.PermissionsBoundary: !Ref AdminPermissionsBoundary` → `AdminRole` depends on `AdminPermissionsBoundary`
- If `AdminPermissionsBoundary.PolicyDocument` references `!GetAtt AdminRole.Arn` → `AdminPermissionsBoundary` depends on `AdminRole`
- → Circular, CFN rejects template at synthesis

The workaround: predict the ARN with `!Sub` (no graph edge created) and **centralize the role-name source** via a CFN Parameter (`AdminRoleSuffix`, etc.) consumed by both `RoleName` and the Deny `Resource`. Renaming the role becomes a single-Parameter change instead of a two-site edit, eliminating the drift hazard #19 named without re-introducing the cycle. Constraint and design choice documented inline in `DenyComplianceRoleTampering`'s comment block.

## Controls Addressed

| Framework | Control | Relevance |
|-----------|---------|-----------|
| NIST 800-53 Rev 5 | CM-2 | Baseline Configuration - explicit cross-stack contract documents the dependency (Layer 1 cannot be deleted while Layer 2 imports its bucket ARN) |
| NIST 800-53 Rev 5 | CM-6 | Configuration Settings - eliminates silent drift between bucket-name template and Layer 2's Resource ARN; eliminates silent drift between RoleName and DenyComplianceRoleTampering's protected ARN |
| FedRAMP High | CM-2, CM-6 | Same |
| CJIS v6.0 | 5.6 | Configuration Management |

## Test Plan

- [x] `cfn-lint cloudformation/01-logging.yaml cloudformation/02-iam-baseline.yaml` — clean
- [x] `aws cloudformation validate-template --template-body file://cloudformation/01-logging.yaml` — clean
- [x] `aws cloudformation validate-template --template-body file://cloudformation/02-iam-baseline.yaml` — clean; returned 8 Parameters including the 4 new ones
- [ ] (Deferred to live deploy) Verify cross-stack dependency: deploy both stacks, attempt `aws cloudformation delete-stack` on Layer 1 → expect failure due to export still imported by Layer 2
- [ ] (Deferred) Verify `DenyComplianceRoleTampering` Resource list resolves to the correct ARNs (positive test: `aws iam simulate-principal-policy` against the resolved role ARNs)

## Closure scope and known follow-ups

- Issue #23 (ARN Path/rename drift mitigation) is partially addressed for `RoleName` drift via the new Parameters. Boundary policy ARN drift (Path changes) is not addressed here — still open.
- Issue #24 (duplicate 15-action S3 list between boundary `Allow` and role inline grant) is unrelated and remains open.

Closes #19
Closes 0XBN-146