### PR TITLE
docs: correct CJIS v6.0 audit timeline to phased rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The baseline pairs with [`oscal-evidence-pipeline`](https://github.com/0xBahalaN
 
 ## CJIS v6.0 Relevance
 
-CJIS v6.0 (audit standard from April 1, 2026) aligns with NIST 800-53 Rev 5 and introduces three material deltas that this baseline directly addresses:
+CJIS v6.0 (published Dec 27, 2024; default audit baseline from April 1, 2026; Priority 2-4 fully enforceable Oct 1, 2027) aligns with NIST 800-53 Rev 5 and introduces three material deltas that this baseline directly addresses:
 
 - **Agency-managed CMK only (SC-12, SC-13, SC-28).** Layer 3 provisions a customer-managed `AWS::KMS::Key` with an explicit key policy. AWS-managed encryption (SSE-S3, default EBS) is replaced everywhere CJI may flow — the Layer 1 CloudTrail log bucket SSE-KMS pass adopts the Layer 3 CMK; Layer 4's Config delivery bucket reuses the same key; Layer 5's SNS topic and DLQ optionally encrypt to the same key via the `ComplianceCmkArn` parameter. CJIS prohibits cloud-provider-held keys for CJI; the architecture forces an agency-CMK posture.
 - **1-year minimum audit retention (AU-9, AU-6).** Layer 1's CloudTrail log bucket uses S3 **Object Lock in COMPLIANCE mode** — neither root nor any IAM principal can delete a log object inside its retention window, providing the WORM-style 1-year retention CJIS requires. The CloudWatch hot mirror provides queryable access for the weekly review without compromising the cold archive.


### PR DESCRIPTION
## Summary
- Corrects the CJIS v6.0 audit-timeline language from a single-cutover framing ("v6.0 becomes/became the audit standard on April 1, 2026") to the verified phased rollout.
- Phased framing: v5.9.5 was the scored audit standard through March 31, 2026; v6.0 is the default audit baseline from April 1, 2026; modernized Priority 2–4 controls fully enforceable Oct 1, 2027 (timing varies by state CSA).
- Surrounding control content (AU-6 / SC-28 / delta mappings) preserved verbatim.

## Why
The April 1, 2026 date is the default go-forward audit baseline, not a one-day enforcement cutover. The corrected framing matches the FBI CJIS v6.0 phased rollout.

## Test Plan
- [x] Dates cross-checked against the canonical reconciled CJIS v6.0 timeline
- [x] Grep sweep — zero residual single-cutover phrasing in tracked files

Factual documentation correction — no issue.