### PR TITLE
docs: align CJIS references to Security Policy v6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![CloudFormation](https://img.shields.io/badge/IaC-CloudFormation-blue?style=flat&logo=amazonwebservices)
 ![License](https://img.shields.io/badge/License-MIT-green?style=flat)
 ![Compliance](https://img.shields.io/badge/Compliance-as%20Code-blueviolet?style=flat)
-![CJIS](https://img.shields.io/badge/CJIS-Security%20Policy%20v6.0-cc0000?style=flat)
+![CJIS](https://img.shields.io/badge/CJIS-Security%20Policy%20v6.1-cc0000?style=flat)
 ![FedRAMP](https://img.shields.io/badge/FedRAMP-High%20Baseline-0071bc?style=flat)
 ![NIST 800-53](https://img.shields.io/badge/NIST-800--53%20Rev%205-004990?style=flat)
 
@@ -43,7 +43,7 @@ SCPs attach at the Organization Root and enforce preventive guardrails across al
 
 ### CJIS Security Policy
 
-The FBI's [CJIS Security Policy](https://le.fbi.gov/file-repository/cjis_security_policy_v6-0_20241227.pdf) sets security requirements for any organization that accesses, stores, or transmits Criminal Justice Information (CJI). That includes law enforcement agencies, cloud providers hosting CJI, and contractors supporting criminal justice systems. Version 6.0 (released December 2024) restructured the policy from 13 to 20 policy areas, now organized by NIST 800-53 control families: Access Control (AC), Auditing and Accountability (AU), Configuration Management (CM), Systems and Communications Protection (SC), and others. Controls use NIST 800-53 identifiers directly. Version 6.0 introduces priority levels (P1 through P4) for phased implementation, with FBI audits underway as of October 2025 and full compliance expected by October 2027.
+The FBI's [CJIS Security Policy](https://le.fbi.gov/file-repository/cjis_security_policy_v6-1_20260625.pdf) sets security requirements for any organization that accesses, stores, or transmits Criminal Justice Information (CJI). That includes law enforcement agencies, cloud providers hosting CJI, and contractors supporting criminal justice systems. Version 6.0 (released December 2024) restructured the policy from 13 to 20 policy areas, now organized by NIST 800-53 control families: Access Control (AC), Auditing and Accountability (AU), Configuration Management (CM), Systems and Communications Protection (SC), and others. Controls use NIST 800-53 identifiers directly. Version 6.0 introduces priority levels (P1 through P4) for phased implementation, with FBI audits underway as of October 2025 and full compliance expected by October 2027.
 
 ### FedRAMP
 
@@ -73,7 +73,7 @@ The [Federal Risk and Authorization Management Program (FedRAMP)](https://www.fe
 
 Each control addresses specific requirements across CJIS Security Policy, FedRAMP, and NIST 800-53. Preventive SCPs and compliant-by-default IaC templates create layered enforcement. SCPs act as guardrails that IAM administrators cannot bypass. CloudFormation ensures new resources meet baseline security requirements without manual configuration.
 
-| Control / Component | CJIS Security Policy (v6.0) | FedRAMP Baseline | NIST 800-53 Rev. 5 |
+| Control / Component | CJIS Security Policy (v6.1) | FedRAMP Baseline | NIST 800-53 Rev. 5 |
 |---|---|---|---|
 | Deny Audit Log Deletion | AU-9 (Protection of Audit Information), AU-12 (Audit Record Generation) | AU-9 (L/M/H), AU-12 (L/M/H) | AU-9 (Protection of Audit Information), AU-12 (Audit Record Generation) |
 | Deny Root User Usage | AC-6 (Least Privilege), AC-3 (Access Enforcement) | AC-6 (M/H), AC-3 (L/M/H) | AC-6 (Least Privilege), AC-3 (Access Enforcement) |
@@ -87,13 +87,13 @@ Each control addresses specific requirements across CJIS Security Policy, FedRAM
 | Layer 5: Detection & Response | SI-3 (Malicious Code Protection), SI-4 (System Monitoring), IR-4 (Incident Handling), IR-5 (Incident Monitoring), IR-6 (Incident Reporting) | SI-3 (L/M/H), SI-4 (L/M/H), IR-4 (L/M/H), IR-5 (L/M/H), IR-6 (L/M/H) | SI-3 (Malicious Code Protection), SI-4 (System Monitoring), IR-4 (Incident Handling), IR-5 (Incident Monitoring), IR-6 (Incident Reporting) |
 | Secure S3 Bucket | SC-28 (Protection of Information at Rest), AC-3 (Access Enforcement) | SC-28 (M/H), AC-3 (L/M/H) | SC-28 (Protection of Information at Rest), AC-3 (Access Enforcement) |
 
-> **Note:** CJIS v6.0 now uses NIST 800-53 control identifiers directly, so the CJIS and NIST columns share the same control IDs. The distinction is that CJIS scopes these requirements specifically to Criminal Justice Information (CJI), while NIST 800-53 applies broadly to federal information systems.
+> **Note:** CJIS v6.x uses NIST 800-53 control identifiers directly, so the CJIS and NIST columns share the same control IDs. The distinction is that CJIS scopes these requirements specifically to Criminal Justice Information (CJI), while NIST 800-53 applies broadly to federal information systems.
 
 > **FedRAMP Baseline Key:** L = Low, M = Moderate, H = High
 
 ## Audit Relevance
 
-An assessor reviewing a FedRAMP High or CJIS v6.0 authorization package can use this baseline as the primary technical control implementation evidence for the AC, AU, IA, SC, CM, SI, and IR control families covered by Layers 1–5 and the five SCPs. The mapping table above is the assessment crosswalk. Each control row points to the specific file (CloudFormation template or SCP JSON) the assessor requests during an EXAMINE procedure.
+An assessor reviewing a FedRAMP High or CJIS v6.1 authorization package can use this baseline as the primary technical control implementation evidence for the AC, AU, IA, SC, CM, SI, and IR control families covered by Layers 1–5 and the five SCPs. The mapping table above is the assessment crosswalk. Each control row points to the specific file (CloudFormation template or SCP JSON) the assessor requests during an EXAMINE procedure.
 
 For walkthrough-style assessments (FedRAMP NIST 800-53A): the templates ARE the as-built configuration documentation. An assessor asks *"show me how you enforce SC-28 at the EBS layer"* and the answer is `03-encryption.yaml`'s `EbsEncryptionByDefault` resource. That source-controlled artifact is the implementation, not a screenshot of the AWS Console at a point in time. Git history is the change-control evidence (CM-3, CM-5). Every modification is reviewable, attributable, and rollback-capable.
 
@@ -113,9 +113,9 @@ FedRAMP 20x restructures the program around compliance-as-code, machine-readable
 
 The baseline pairs with [`oscal-evidence-pipeline`](https://github.com/0xBahalaNa/oscal-evidence-pipeline), which transforms these JSON evidence streams into OSCAL Assessment Results (SAR) JSON for FedRAMP 20x submission packages. The August 2026 Terraform conversion (per the Sprint Plan) also covers the CGE-P IaC Portfolio submission: Terraform + OPA/Rego + CI/CD pipeline + KSI dashboard delivered against this baseline's already-defined control set.
 
-## CJIS v6.0 Relevance
+## CJIS v6.1 Relevance
 
-CJIS v6.0 (published Dec 27, 2024; default audit baseline from April 1, 2026; Priority 2-4 fully enforceable Oct 1, 2027) aligns with NIST 800-53 Rev 5. Three material deltas this baseline addresses:
+CJIS Security Policy v6.1 (released June 25, 2026) is the current policy, aligned with NIST 800-53 Rev 5. v6.x has been the default audit baseline since April 1, 2026 (v5.9.5 sunset March 31, 2026); modernized Priority 2-4 controls are fully enforceable Oct 1, 2027 (timing varies by state CSA). Three material deltas this baseline addresses:
 
 - **Agency-managed CMK only (SC-12, SC-13, SC-28).** Layer 3 provisions a customer-managed `AWS::KMS::Key` with an explicit key policy. AWS-managed encryption (SSE-S3, default EBS) is replaced everywhere CJI may flow. The Layer 1 CloudTrail log bucket SSE-KMS pass adopts the Layer 3 CMK. Layer 4's Config delivery bucket reuses the same key. Layer 5's SNS topic and DLQ optionally encrypt to the same key via the `ComplianceCmkArn` parameter. CJIS prohibits cloud-provider-held keys for CJI; the architecture forces an agency-CMK posture.
 - **1-year minimum audit retention (AU-9, AU-6).** Layer 1's CloudTrail log bucket uses S3 Object Lock in COMPLIANCE mode. Neither root nor any IAM principal can delete a log object inside its retention window. That is the WORM-style 1-year retention CJIS requires. The CloudWatch hot mirror provides queryable access for the weekly review without compromising the cold archive.
@@ -425,7 +425,7 @@ aws cloudformation deploy \
         --query "Stacks[0].Outputs[?OutputKey=='ComplianceCmkArn'].OutputValue" --output text)
 ```
 
-**Layer 5: Detection & Response.** Provide the email address for high-severity alerts. SNS sends a confirmation email. The subscription is **not** active until the recipient clicks the link, so after deploy run `aws sns list-subscriptions-by-topic` (the stack's `PostDeployVerification` output gives the exact command) to confirm `SubscriptionArn != "PendingConfirmation"`. **If the account already has GuardDuty or Security Hub enabled** (Control Tower, console, or a prior stack), add `ManageDetectionServices=UseExisting` to skip the singleton resources (the NIST 800-53 Rev 5 standard subscription still runs. Control Tower / console hubs default to AWS FSBP, not NIST 800-53). **To encrypt the SNS topic and DLQ with the Layer 3 agency CMK** (carries the SC-28 / CJIS 5.10.1.2 story through), also pass `ComplianceCmkArn`:
+**Layer 5: Detection & Response.** Provide the email address for high-severity alerts. SNS sends a confirmation email. The subscription is **not** active until the recipient clicks the link, so after deploy run `aws sns list-subscriptions-by-topic` (the stack's `PostDeployVerification` output gives the exact command) to confirm `SubscriptionArn != "PendingConfirmation"`. **If the account already has GuardDuty or Security Hub enabled** (Control Tower, console, or a prior stack), add `ManageDetectionServices=UseExisting` to skip the singleton resources (the NIST 800-53 Rev 5 standard subscription still runs. Control Tower / console hubs default to AWS FSBP, not NIST 800-53). **To encrypt the SNS topic and DLQ with the Layer 3 agency CMK** (carries the SC-28(1) agency-managed key delta story through), also pass `ComplianceCmkArn`:
 
 ```
 aws cloudformation deploy \
@@ -488,7 +488,7 @@ aws cloudformation delete-stack \
 
 The following resources informed the design of this project:
 
-- [FBI CJIS Security Policy v6.0](https://le.fbi.gov/file-repository/cjis_security_policy_v6-0_20241227.pdf)
+- [FBI CJIS Security Policy v6.1](https://le.fbi.gov/file-repository/cjis_security_policy_v6-1_20260625.pdf)
 - [FedRAMP Security Controls Baselines](https://www.fedramp.gov/baselines/)
 - [GRC Engineering for AWS by AJ Yawn](https://ajyawn.com/books)
 - [GRC Engineering for AWS Chapter 5 Repository](https://github.com/ajy0127/thegrcengineeringbook/tree/master/chapter-5)

--- a/cloudformation/01-logging.yaml
+++ b/cloudformation/01-logging.yaml
@@ -3,11 +3,11 @@ Description: >-
   Layer 1 - Logging & Monitoring. Deploys a multi-region CloudTrail with a
   tamper-proof S3 log bucket (Object Lock in COMPLIANCE mode), a CloudWatch
   Log Group for near-real-time delivery, and a VPC Flow Log on the default
-  VPC. Satisfies NIST 800-53 Rev 5 AU-2, AU-3, AU-9, AU-12. Partial CJIS v6.0
+  VPC. Satisfies NIST 800-53 Rev 5 AU-2, AU-3, AU-9, AU-12. Partial CJIS v6.1
   5.4.1 - integrity controls in place; S3 long-term store encryption-at-rest
   closes by passing the Layer 3 CMK ARN to the LogsBucketCmkArn parameter
   (agency-managed key). CloudWatch Logs hot-mirror remains under AWS-managed
-  encryption; full CJI-at-rest (5.10.1.2) closure deferred to v1.2.0.
+  encryption; full CJI-at-rest (SC-28(1)) closure deferred to v1.2.0.
   Bucket-policy lockdown (s3:PutBucketPolicy / s3:DeleteBucketPolicy denied
   to everyone except the Layer 2 audit admin role) wires in via the optional
   AuditAdminRoleArn parameter - same two-pass pattern as the CMK. Every
@@ -66,7 +66,7 @@ Parameters:
       not exist yet, so the logs bucket falls back to SSE-S3 (AES256).
       After Layer 3 is deployed, update this stack with the CMK ARN to
       switch the bucket to SSE-KMS with the agency-managed key (SC-28 /
-      CJIS 5.10.1.2). Two-pass by design: Layer 1 is numbered first but
+      CJIS SC-28(1)). Two-pass by design: Layer 1 is numbered first but
       its encryption key is created in Layer 3.
 
   AuditAdminRoleArn:
@@ -159,7 +159,7 @@ Resources:
         ServerSideEncryptionConfiguration:
           # SSE-KMS with the Layer 3 agency-managed CMK once its ARN is
           # wired in via LogsBucketCmkArn; SSE-S3 (AES256) as the
-          # pre-Layer-3 fallback. CJIS v6.0 5.10.1.2 requires an
+          # pre-Layer-3 fallback. CJIS v6.1 SC-28(1) requires an
           # agency-managed key for CJI at rest - the CMK branch closes
           # that gap; AES256 alone uses an AWS-managed key.
           - ServerSideEncryptionByDefault:

--- a/cloudformation/02-iam-baseline.yaml
+++ b/cloudformation/02-iam-baseline.yaml
@@ -25,9 +25,9 @@ Description: >-
   PutBucketPolicy). Both boundary policies carry DenyBoundarySelfMutation,
   blocking the four ManagedPolicy mutation verbs on both boundary ARNs to
   close the boundary-self-rewrite escalation. Satisfies NIST 800-53 Rev 5
-  AC-2, AC-3, AC-6, AC-6(9), AC-6(10), IA-5, CM-5. Partial CJIS v6.0
-  5.6.2.1 (password attributes via IA-5); AAL2 phishing-resistant MFA
-  (5.6.2.2 / IA-2) deferred to IAM Identity Center work.
+  AC-2, AC-3, AC-6, AC-6(9), AC-6(10), IA-5, CM-5. Partial CJIS v6.1
+  IA-5 (password attributes); AAL2 phishing-resistant MFA
+  (IA-2) deferred to IAM Identity Center work.
 
 Parameters:
   MinimumPasswordLength:
@@ -36,7 +36,7 @@ Parameters:
     MinValue: 14
     MaxValue: 128
     Description: >-
-      Minimum password length. FedRAMP High baseline is 12; CJIS v6.0 aligns
+      Minimum password length. FedRAMP High baseline is 12; CJIS v6.1 aligns
       with NIST 800-63B (8+ recommended for AAL1, 14+ for AAL2 with memorized
       secrets). 14 is the conservative pick that covers both.
 

--- a/cloudformation/03-encryption.yaml
+++ b/cloudformation/03-encryption.yaml
@@ -5,7 +5,7 @@ Description: >-
   key usage; a stable alias; and account-level EBS encryption-by-default (via a
   Lambda-backed custom resource) pointed at the CMK. The CMK ARN is exported so
   Layer 1 can adopt it for the CloudTrail logs bucket. Satisfies NIST 800-53
-  Rev 5 SC-12, SC-13, SC-28, SC-28(1). CJIS v6.0 5.10.1.2 - agency-managed key
+  Rev 5 SC-12, SC-13, SC-28, SC-28(1). CJIS v6.1 SC-28(1) - agency-managed key
   for CJI at rest; an AWS-managed key would place AWS personnel in CJIS scope.
 
 Parameters:
@@ -52,8 +52,8 @@ Parameters:
 
 Resources:
 
-  # The customer-managed CMK. This is the "agency-managed key" CJIS v6.0
-  # (5.10.1.2) requires for CJI at rest: the account - not AWS - owns the key
+  # The customer-managed CMK. This is the "agency-managed key" CJIS v6.1
+  # SC-28(1) requires for CJI at rest: the account - not AWS - owns the key
   # policy and the key lifecycle, so AWS personnel cannot decrypt data
   # protected by it. An AWS-managed key (aws/s3, aws/ebs) cannot satisfy this
   # because AWS controls that key's policy.
@@ -69,7 +69,7 @@ Resources:
     Properties:
       Description: >-
         Compliance baseline CMK. Encrypts CloudTrail logs (S3) and EBS volumes
-        at rest. NIST 800-53 SC-12 / SC-13 / SC-28; CJIS v6.0 5.10.1.2.
+        at rest. NIST 800-53 SC-12 / SC-13 / SC-28; CJIS v6.1 SC-28(1).
       KeySpec: SYMMETRIC_DEFAULT
       KeyUsage: ENCRYPT_DECRYPT
       # Single-region key. CLAUDE.md: do not span regions unless the control
@@ -312,7 +312,7 @@ Resources:
                       # survives stack teardown and the account EBS default
                       # can safely keep referencing it. Resetting to the
                       # AWS-managed aws/ebs key here would be a silent CJIS
-                      # 5.10.1.2 regression; decommissioning the CMK is a
+                      # SC-28(1) regression; decommissioning the CMK is a
                       # deliberate, separate action.
                       pass
                   cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, PHYSICAL_ID)

--- a/cloudformation/04-config.yaml
+++ b/cloudformation/04-config.yaml
@@ -12,8 +12,8 @@ Description: >-
   the ManageConfigService parameter: pass UseExisting when the account already
   has AWS Config enabled in this region (Control Tower, console-onboarding,
   another stack) and only the rules are created, evaluating against the
-  existing recorder. Satisfies NIST 800-53 Rev 5 CM-2, CM-6, CM-8; CJIS v6.0
-  5.10.4.1.
+  existing recorder. Satisfies NIST 800-53 Rev 5 CM-2, CM-6, CM-8; CJIS v6.1
+  CM-6.
 
 Parameters:
   ConfigCmkArn:
@@ -23,7 +23,7 @@ Parameters:
     Description: >-
       ARN of the Layer 3 compliance CMK (03-encryption.yaml output
       ComplianceCmkArn). Encrypts the Config delivery bucket with the
-      agency-managed key (SC-28 / CJIS 5.10.1.2). The CMK MUST be in the
+      agency-managed key (SC-28(1) agency-managed key delta). The CMK MUST be in the
       same AWS region as this stack: S3 SSE-KMS requires a same-region key,
       so passing a cross-region ARN fails bucket creation with
       KMS.NotFoundException. Required even when ManageConfigService=
@@ -365,7 +365,7 @@ Resources:
           - AWS::S3::Bucket
 
   # Strict CJIS check: S3 buckets must use SSE-KMS (not SSE-S3 / AES256).
-  # The AWS-managed aws/s3 key does not satisfy CJIS 5.10.1.2's
+  # The AWS-managed aws/s3 key does not satisfy CJIS SC-28(1)'s
   # agency-managed-key requirement; this rule surfaces any bucket relying
   # on it. The secure-bucket.yaml legacy template and the pre-second-pass
   # Layer 1 bucket will report NON_COMPLIANT here - that is the intended
@@ -374,7 +374,7 @@ Resources:
     Type: AWS::Config::ConfigRule
     Properties:
       ConfigRuleName: s3-default-encryption-kms
-      Description: Verifies S3 buckets default to SSE-KMS (CJIS 5.10.1.2 - agency-managed key).
+      Description: Verifies S3 buckets default to SSE-KMS (CJIS SC-28(1) - agency-managed key).
       Source:
         Owner: AWS
         SourceIdentifier: S3_DEFAULT_ENCRYPTION_KMS

--- a/cloudformation/05-detection.yaml
+++ b/cloudformation/05-detection.yaml
@@ -12,7 +12,7 @@ Description: >-
   always wired up. SNS and SQS encrypt with the optional Layer 3 CMK when
   ComplianceCmkArn is supplied, otherwise the AWS-managed alias/aws/sns
   and alias/aws/sqs keys. Satisfies NIST 800-53 Rev 5 SI-3, SI-4, IR-4,
-  IR-5, IR-6; CJIS v6.0 5.10.4.2.
+  IR-5, IR-6; CJIS v6.1 IR-5/IR-6.
 
 Parameters:
   SecurityAlertEmail:
@@ -53,7 +53,7 @@ Parameters:
       Optional ARN of the Layer 3 compliance CMK (03-encryption.yaml output
       ComplianceCmkArn). When supplied, the SNS topic AND SQS DLQ are
       encrypted with the agency-managed CMK (carries the SC-28 / CJIS
-      5.10.1.2 story forward). When empty (the default), they fall back
+      SC-28(1) story forward). When empty (the default), they fall back
       to the AWS-managed alias/aws/sns and alias/aws/sqs keys. The Layer 3
       CMK key policy must allow sns.amazonaws.com and sqs.amazonaws.com
       GenerateDataKey for this option to work - the Layer 3 template


### PR DESCRIPTION
## Summary
- Updated all CJIS references from Security Policy v6.0 to v6.1 (released 06/25/2026, CY2025 APB corrections release)
- Applied the canonical rollout wording: v6.x default audit baseline since April 1, 2026 (v5.9.5 sunset March 31, 2026); Priority 2-4 fully enforceable Oct 1, 2027
- Replaced remaining legacy v5.9-style section citations with 800-53 control-ID citations where present

## Test Plan
- [x] grep sweep: no remaining v6.0 version strings or legacy 5.x citations in living files